### PR TITLE
Nest Moon and MoonPhase objects under TinyMoon namespace

### DIFF
--- a/Sources/TinyMoon/TinyMoon.swift
+++ b/Sources/TinyMoon/TinyMoon.swift
@@ -1,188 +1,188 @@
 import Foundation
 
-public struct Moon: Hashable {
-  init(date: Date) {
-    self.date = date
-    self.lunarDay = Moon.lunarDay(for: date)
-    self.maxLunarDay = Moon.maxLunarDayInCycle(starting: date)
-    self.moonPhase = Moon.moonPhase(lunarDay: Int(floor(lunarDay)))
-    self.name = moonPhase.rawValue
-    self.emoji = moonPhase.emoji
-  }
-
-  public let moonPhase: MoonPhase
-  public let name: String
-  public let emoji: String
-  public let lunarDay: Double
-  public let maxLunarDay: Double
-  public let date: Date
-  private var wholeLunarDay: Int {
-    Int(floor(lunarDay))
-  }
-
-  // Returns `0` if the current `date` is a full moon
-  public var daysTillFullMoon: Int {
-    if wholeLunarDay > 14 {
-      return 29 - wholeLunarDay + 14
-    } else {
-      return 14 - wholeLunarDay
-    }
-  }
-
-  // Returns `0` if the current `date` is a new moon
-  public var daysTillNewMoon: Int {
-    if wholeLunarDay == 0 {
-      return 0
-    } else {
-      let daysTillNextNewMoon = Int(ceil(maxLunarDay)) - wholeLunarDay
-      return daysTillNextNewMoon
-    }
-  }
-
-  public func isFullMoon() -> Bool {
-    switch moonPhase {
-    case .fullMoon: true
-    default: false
-    }
-  }
-
-  public var fullMoonName: String? {
-    if isFullMoon() {
-      let calendar = Calendar.current
-      let components = calendar.dateComponents([.month], from: date)
-      if let month = components.month {
-        return fullMoonName(month: month)
-      }
-    }
-    return nil
-  }
-
-  private func fullMoonName(month: Int) -> String? {
-    switch month {
-    case 1: "Wolf Moon"
-    case 2: "Snow Moon"
-    case 3: "Worm Moon"
-    case 4: "Pink Moon"
-    case 5: "Flower Moon"
-    case 6: "Strawberry Moon"
-    case 7: "Buck Moon"
-    case 8: "Sturgeon Moon"
-    case 9: "Harvest Moon"
-    case 10: "Hunter's Moon"
-    case 11: "Beaver Moon"
-    case 12: "Cold Moon"
-    default: nil
-    }
-  }
-
-  internal static func lunarDay(for date: Date) -> Double {
-    let synodicMonth = 29.53058770576
-    let calendar = Calendar.current
-    let components = calendar.dateComponents([.day, .month, .year], from: date)
-    guard
-      let year = components.year,
-      let month = components.month,
-      let day = components.day
-    else {
-      print("Error: Cannot resolve year, month, or day.")
-      FileHandle.standardError.write("Error: Cannot resolve year, month, or day".data(using: .utf8)!)
-      exit(1)
-    }
-    // Days between a known new moon date (January 6th, 2000) and the given day
-    let dateDifference = julianDay(year: year, month: month, day: day) - julianDay(year: 2000, month: 1, day: 6)
-    // Divide by synodic month `29.53058770576`
-    let lunarDay = (dateDifference / synodicMonth).truncatingRemainder(dividingBy: 1) * synodicMonth
-    return lunarDay
-  }
-
-  internal static func maxLunarDayInCycle(starting date: Date) -> Double {
-    let maxLunarDay = lunarDay(for: date)
-    let calendar = Calendar.current
-    if let tomorrow = calendar.date(byAdding: .day, value: 1, to: date) {
-      if lunarDay(for: tomorrow) < maxLunarDay {
-        return maxLunarDay
-      } else {
-        return maxLunarDayInCycle(starting: tomorrow)
-      }
-    }
-    return maxLunarDay
-  }
-
-  internal static func moonPhase(lunarDay: Int) -> MoonPhase {
-    if lunarDay < 1  {
-      return .newMoon
-    } else if lunarDay < 6 {
-      return .waxingCrescent
-    } else if lunarDay < 7 {
-      return .firstQuarter
-    } else if lunarDay < 14 {
-      return .waxingGibbous
-    } else if lunarDay < 15 {
-      return .fullMoon
-    } else if lunarDay < 21 {
-      return .waningGibbous
-    } else if lunarDay < 22 {
-      return .lastQuarter
-    } else if lunarDay < 30 {
-      return .waningCrescent
-    } else {
-      return .newMoon
-    }
-  }
-
-  /// The Julian Day Count is a uniform count of days from a remote epoch in the past and is used for calculating the days between two events.
-  /// The Julian day is calculated by combining the contributions from the years, months, and day, taking into account constant offsets and rounding down the result.
-  /// https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
-  private static func julianDay(year: Int, month: Int, day: Int) -> Double {
-    var newYear = year
-    var newMonth = month
-    if month <= 2 {
-      newYear = year - 1
-      newMonth = month + 12
-    }
-    let a = Int(newYear / 100)
-    let b = Int(a / 4)
-    let c = 2 - a + b
-    let e = Int(365.25 * Double(newYear + 4716))
-    let f = Int(30.6001 * Double(newMonth + 1))
-    return Double(c + day + e + f) - 1524.5
-  }
-}
-
-public enum MoonPhase: String {
-  case newMoon          = "New Moon"
-  case waxingCrescent   = "Waxing Crescent"
-  case firstQuarter     = "First Quarter"
-  case waxingGibbous    = "Waxing Gibbous"
-  case fullMoon         = "Full Moon"
-  case waningGibbous    = "Waning Gibbous"
-  case lastQuarter      = "Last Quarter"
-  case waningCrescent   = "Waning Crescent"
-
-  var emoji: String {
-    switch self {
-    case .newMoon:
-      "\u{1F311}" // 🌑
-    case .waxingCrescent:
-      "\u{1F312}" // 🌒
-    case .firstQuarter:
-      "\u{1F313}" // 🌓
-    case .waxingGibbous:
-      "\u{1F314}" // 🌔
-    case .fullMoon:
-      "\u{1F315}" // 🌕
-    case .waningGibbous:
-      "\u{1F316}" // 🌖
-    case .lastQuarter:
-      "\u{1F317}" // 🌗
-    case .waningCrescent:
-      "\u{1F318}" // 🌘
-    }
-  }
-}
-
 public enum TinyMoon {
   public static func calculateMoonPhase(_ date: Date = Date()) -> Moon {
     Moon(date: date)
+  }
+
+  public struct Moon: Hashable {
+    init(date: Date) {
+      self.date = date
+      self.lunarDay = Moon.lunarDay(for: date)
+      self.maxLunarDay = Moon.maxLunarDayInCycle(starting: date)
+      self.moonPhase = Moon.moonPhase(lunarDay: Int(floor(lunarDay)))
+      self.name = moonPhase.rawValue
+      self.emoji = moonPhase.emoji
+    }
+
+    public let moonPhase: MoonPhase
+    public let name: String
+    public let emoji: String
+    public let lunarDay: Double
+    public let maxLunarDay: Double
+    public let date: Date
+    private var wholeLunarDay: Int {
+      Int(floor(lunarDay))
+    }
+
+    // Returns `0` if the current `date` is a full moon
+    public var daysTillFullMoon: Int {
+      if wholeLunarDay > 14 {
+        return 29 - wholeLunarDay + 14
+      } else {
+        return 14 - wholeLunarDay
+      }
+    }
+
+    // Returns `0` if the current `date` is a new moon
+    public var daysTillNewMoon: Int {
+      if wholeLunarDay == 0 {
+        return 0
+      } else {
+        let daysTillNextNewMoon = Int(ceil(maxLunarDay)) - wholeLunarDay
+        return daysTillNextNewMoon
+      }
+    }
+
+    public func isFullMoon() -> Bool {
+      switch moonPhase {
+      case .fullMoon: true
+      default: false
+      }
+    }
+
+    public var fullMoonName: String? {
+      if isFullMoon() {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.month], from: date)
+        if let month = components.month {
+          return fullMoonName(month: month)
+        }
+      }
+      return nil
+    }
+
+    private func fullMoonName(month: Int) -> String? {
+      switch month {
+      case 1: "Wolf Moon"
+      case 2: "Snow Moon"
+      case 3: "Worm Moon"
+      case 4: "Pink Moon"
+      case 5: "Flower Moon"
+      case 6: "Strawberry Moon"
+      case 7: "Buck Moon"
+      case 8: "Sturgeon Moon"
+      case 9: "Harvest Moon"
+      case 10: "Hunter's Moon"
+      case 11: "Beaver Moon"
+      case 12: "Cold Moon"
+      default: nil
+      }
+    }
+
+    internal static func lunarDay(for date: Date) -> Double {
+      let synodicMonth = 29.53058770576
+      let calendar = Calendar.current
+      let components = calendar.dateComponents([.day, .month, .year], from: date)
+      guard
+        let year = components.year,
+        let month = components.month,
+        let day = components.day
+      else {
+        print("Error: Cannot resolve year, month, or day.")
+        FileHandle.standardError.write("Error: Cannot resolve year, month, or day".data(using: .utf8)!)
+        exit(1)
+      }
+      // Days between a known new moon date (January 6th, 2000) and the given day
+      let dateDifference = julianDay(year: year, month: month, day: day) - julianDay(year: 2000, month: 1, day: 6)
+      // Divide by synodic month `29.53058770576`
+      let lunarDay = (dateDifference / synodicMonth).truncatingRemainder(dividingBy: 1) * synodicMonth
+      return lunarDay
+    }
+
+    internal static func maxLunarDayInCycle(starting date: Date) -> Double {
+      let maxLunarDay = lunarDay(for: date)
+      let calendar = Calendar.current
+      if let tomorrow = calendar.date(byAdding: .day, value: 1, to: date) {
+        if lunarDay(for: tomorrow) < maxLunarDay {
+          return maxLunarDay
+        } else {
+          return maxLunarDayInCycle(starting: tomorrow)
+        }
+      }
+      return maxLunarDay
+    }
+
+    internal static func moonPhase(lunarDay: Int) -> MoonPhase {
+      if lunarDay < 1  {
+        return .newMoon
+      } else if lunarDay < 6 {
+        return .waxingCrescent
+      } else if lunarDay < 7 {
+        return .firstQuarter
+      } else if lunarDay < 14 {
+        return .waxingGibbous
+      } else if lunarDay < 15 {
+        return .fullMoon
+      } else if lunarDay < 21 {
+        return .waningGibbous
+      } else if lunarDay < 22 {
+        return .lastQuarter
+      } else if lunarDay < 30 {
+        return .waningCrescent
+      } else {
+        return .newMoon
+      }
+    }
+
+    /// The Julian Day Count is a uniform count of days from a remote epoch in the past and is used for calculating the days between two events.
+    /// The Julian day is calculated by combining the contributions from the years, months, and day, taking into account constant offsets and rounding down the result.
+    /// https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
+    private static func julianDay(year: Int, month: Int, day: Int) -> Double {
+      var newYear = year
+      var newMonth = month
+      if month <= 2 {
+        newYear = year - 1
+        newMonth = month + 12
+      }
+      let a = Int(newYear / 100)
+      let b = Int(a / 4)
+      let c = 2 - a + b
+      let e = Int(365.25 * Double(newYear + 4716))
+      let f = Int(30.6001 * Double(newMonth + 1))
+      return Double(c + day + e + f) - 1524.5
+    }
+  }
+
+  public enum MoonPhase: String {
+    case newMoon          = "New Moon"
+    case waxingCrescent   = "Waxing Crescent"
+    case firstQuarter     = "First Quarter"
+    case waxingGibbous    = "Waxing Gibbous"
+    case fullMoon         = "Full Moon"
+    case waningGibbous    = "Waning Gibbous"
+    case lastQuarter      = "Last Quarter"
+    case waningCrescent   = "Waning Crescent"
+
+    var emoji: String {
+      switch self {
+      case .newMoon:
+        "\u{1F311}" // 🌑
+      case .waxingCrescent:
+        "\u{1F312}" // 🌒
+      case .firstQuarter:
+        "\u{1F313}" // 🌓
+      case .waxingGibbous:
+        "\u{1F314}" // 🌔
+      case .fullMoon:
+        "\u{1F315}" // 🌕
+      case .waningGibbous:
+        "\u{1F316}" // 🌖
+      case .lastQuarter:
+        "\u{1F317}" // 🌗
+      case .waningCrescent:
+        "\u{1F318}" // 🌘
+      }
+    }
   }
 }

--- a/Tests/TinyMoonTests/TestHelper.swift
+++ b/Tests/TinyMoonTests/TestHelper.swift
@@ -10,6 +10,26 @@ struct TestHelper {
     return formatter
   }
 
+  static func prettyPrint(_ moon: TinyMoon.Moon) {
+    var title = ""
+    switch moon.moonPhase {
+    case .newMoon, .firstQuarter, .fullMoon, .lastQuarter:
+      title = "\(moon.emoji) \(moon.moonPhase)"
+    default:
+      title = "\(moon.moonPhase) \(moon.emoji) "
+    }
+    let prettyString = """
+    ...
+    \(moon.date)
+      \(title)
+      - lunarDay: \(moon.lunarDay)
+      - maxLunarDay: \(moon.maxLunarDay)
+      - daysTillFullMoon: \(moon.daysTillFullMoon)
+      - daysTillNewMoon: \(moon.daysTillNewMoon)
+    """
+    print(prettyString)
+  }
+
   static func formatDate(year: Int, month: Int, day: Int) -> Date {
     guard let date = TestHelper.dateFormatter.date(from: "\(year)/\(month)/\(day) 00:00") else {
       fatalError("Invalid date")

--- a/Tests/TinyMoonTests/TestHelper.swift
+++ b/Tests/TinyMoonTests/TestHelper.swift
@@ -18,15 +18,15 @@ struct TestHelper {
   }
 
   /// Helper function to return a moon object for a given Date
-  static func moonDay(year: Int, month: Int, day: Int) -> Moon {
+  static func moonDay(year: Int, month: Int, day: Int) -> TinyMoon.Moon {
     let date = TestHelper.formatDate(year: year, month: month, day: day)
     let moon = TinyMoon.calculateMoonPhase(date)
     return moon
   }
 
   /// Helper function to return an array of moon objects for a given range of Dates
-  static func moonRange(year: Int, month: Int, days: ClosedRange<Int>) -> [Moon] {
-    var moons: [Moon] = []
+  static func moonRange(year: Int, month: Int, days: ClosedRange<Int>) -> [TinyMoon.Moon] {
+    var moons: [TinyMoon.Moon] = []
 
     moons = days.map({ day in
       moonDay(year: year, month: month, day: day)
@@ -36,8 +36,8 @@ struct TestHelper {
   }
 
   /// Helper function to return a full month's moon objects
-  static func moonMonth(month: Helper.Month) -> [Moon] {
-    var moons: [Moon] = []
+  static func moonMonth(month: Helper.Month) -> [TinyMoon.Moon] {
+    var moons: [TinyMoon.Moon] = []
 
     Helper.months2024[month]?.forEach({ day in
       moons.append(moonDay(year: 2024, month: month.rawValue, day: day))


### PR DESCRIPTION
Closes #13 

Simplifies the API by nesting the Moon and MoonPhase objects under the `TinyMoon` namespace.

This helps with namespace clarity, making it clearer that Moon is part of TinyMoon, `TinyMoon.Moon` vs just `Moon`. Also helps to reduce global namespace pollution.

Current behavior:

```swift
public struct Moon: Hashable {…}

public enum MoonPhase: String {...}

public enum TinyMoon {
  public static func calculateMoonPhase(_ date: Date = Date()) -> Moon {
    Moon(date: date)
  }
}

let moon = TinyMoon.calculateMoonPhase(Date())
let moon2 = Moon(Date())
```

Expected behavior:

```swift
public enum TinyMoon {
  public static func calculateMoonPhase(_ date: Date = Date()) -> Moon {
    Moon(date: date)
  }

  public struct Moon: Hashable {…}

  public enum MoonPhase: String {...}
}

let moon = TinyMoon.calculateMoonPhase(Date())
let moon2 = TinyMoon.Moon(Date())
```
