### PR TITLE
Refactor julian day

### DIFF
--- a/Sources/TinyMoon/TinyMoon.swift
+++ b/Sources/TinyMoon/TinyMoon.swift
@@ -83,7 +83,7 @@ public enum TinyMoon {
     internal static func lunarDay(for date: Date) -> Double {
       let synodicMonth = 29.53058770576
       let calendar = Calendar.current
-      let components = calendar.dateComponents([.day, .month, .year], from: date)
+      let components = calendar.dateComponents([.year, .month, .day], from: date)
       guard
         let year = components.year,
         let month = components.month,
@@ -138,7 +138,7 @@ public enum TinyMoon {
     /// The Julian Day Count is a uniform count of days from a remote epoch in the past and is used for calculating the days between two events.
     /// The Julian day is calculated by combining the contributions from the years, months, and day, taking into account constant offsets and rounding down the result.
     /// https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
-    private static func julianDay(year: Int, month: Int, day: Int) -> Double {
+    internal static func julianDay(year: Int, month: Int, day: Int) -> Double {
       var newYear = year
       var newMonth = month
       if month <= 2 {
@@ -151,6 +151,35 @@ public enum TinyMoon {
       let e = Int(365.25 * Double(newYear + 4716))
       let f = Int(30.6001 * Double(newMonth + 1))
       return Double(c + day + e + f) - 1524.5
+    }
+
+    /// The Julian Day Count is a uniform count of days from a remote epoch in the past and is used for calculating the days between two events.
+    /// The Julian day is calculated by combining the contributions from the years, months, and day, taking into account constant offsets and rounding down the result.
+    /// https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
+    internal static func julianDay(_ date: Date) -> Double {
+      let calendar = Calendar(identifier: .gregorian)
+      let components = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+      
+      guard let year = components.year, let month = components.month, let day = components.day, let hour = components.hour, let minute = components.minute, let second = components.second else {
+        fatalError("Could not extract date components")
+      }
+
+      let a = (14 - month) / 12
+      let y = year + 4800 - a
+      let m = month + 12 * a - 3
+
+      // Calculate Julian Day Number for the date
+      let jdn = Double(day) + Double((153 * m + 2) / 5) + Double(y) * 365 + Double(y / 4) - Double(y / 100) + Double(y / 400) - 32045
+
+      // Calculate the fraction of the day
+      let dayFraction = (Double(hour) - 12) / 24 + Double(minute) / 1440 + Double(second) / 86400
+
+      // Add the day fraction to the Julian Day Number
+      let julianDayWithTime = jdn + dayFraction
+
+      let roundedJulianDay = (julianDayWithTime * 10000).rounded() / 10000
+
+      return roundedJulianDay
     }
   }
 

--- a/Sources/TinyMoon/TinyMoon.swift
+++ b/Sources/TinyMoon/TinyMoon.swift
@@ -82,8 +82,11 @@ public enum TinyMoon {
 
     internal static func lunarDay(for date: Date) -> Double {
       let synodicMonth = 29.53058770576
-      let calendar = Calendar.current
+
+      var calendar = Calendar.current
+      calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? calendar.timeZone
       let components = calendar.dateComponents([.year, .month, .day], from: date)
+
       guard
         let year = components.year,
         let month = components.month,
@@ -157,9 +160,10 @@ public enum TinyMoon {
     /// The Julian day is calculated by combining the contributions from the years, months, and day, taking into account constant offsets and rounding down the result.
     /// https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
     internal static func julianDay(_ date: Date) -> Double {
-      let calendar = Calendar(identifier: .gregorian)
+      var calendar = Calendar.current
+      calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? calendar.timeZone
       let components = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
-      
+
       guard let year = components.year, let month = components.month, let day = components.day, let hour = components.hour, let minute = components.minute, let second = components.second else {
         fatalError("Could not extract date components")
       }
@@ -213,5 +217,25 @@ public enum TinyMoon {
         "\u{1F318}" // 🌘
       }
     }
+  }
+
+  private static var dateFormatter: DateFormatter {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy/MM/dd HH:mm"
+    formatter.timeZone = TimeZone(identifier: "UTC")
+    return formatter
+  }
+
+  static func formatDate(
+    year: Int,
+    month: Int,
+    day: Int,
+    hour: Int = 00,
+    minute: Int = 00) -> Date
+  {
+    guard let date = TinyMoon.dateFormatter.date(from: "\(year)/\(month)/\(day) \(hour):\(minute)") else {
+      fatalError("Invalid date")
+    }
+    return date
   }
 }

--- a/Sources/TinyMoon/TinyMoon.swift
+++ b/Sources/TinyMoon/TinyMoon.swift
@@ -80,7 +80,7 @@ public enum TinyMoon {
       }
     }
 
-    internal static func lunarDay(for date: Date) -> Double {
+    internal static func lunarDay(for date: Date, usePreciseJulianDay: Bool = false) -> Double {
       let synodicMonth = 29.53058770576
 
       var calendar = Calendar.current
@@ -96,8 +96,16 @@ public enum TinyMoon {
         FileHandle.standardError.write("Error: Cannot resolve year, month, or day".data(using: .utf8)!)
         exit(1)
       }
-      // Days between a known new moon date (January 6th, 2000) and the given day
-      let dateDifference = julianDay(year: year, month: month, day: day) - julianDay(year: 2000, month: 1, day: 6)
+
+      var dateDifference: Double
+      if usePreciseJulianDay {
+        // Days between the given day and a known new moon date (January 6th, 2000)
+        let knownNewMoonDate = TinyMoon.formatDate(year: 2000, month: 01, day: 06, hour: 18, minute: 13)
+        dateDifference = julianDay(date) - julianDay(knownNewMoonDate)
+      } else {
+        // Days between a known new moon date (January 6th, 2000) and the given day
+        dateDifference = lessPreciseJulianDay(year: year, month: month, day: day) - lessPreciseJulianDay(year: 2000, month: 1, day: 6)
+      }
       // Divide by synodic month `29.53058770576`
       let lunarDay = (dateDifference / synodicMonth).truncatingRemainder(dividingBy: 1) * synodicMonth
       return lunarDay
@@ -141,7 +149,8 @@ public enum TinyMoon {
     /// The Julian Day Count is a uniform count of days from a remote epoch in the past and is used for calculating the days between two events.
     /// The Julian day is calculated by combining the contributions from the years, months, and day, taking into account constant offsets and rounding down the result.
     /// https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
-    internal static func julianDay(year: Int, month: Int, day: Int) -> Double {
+    /// - Note: This version does not use hours or minutes to compute the Julian Day, so it will only return up to one decimal point of accuracy.
+    internal static func lessPreciseJulianDay(year: Int, month: Int, day: Int) -> Double {
       var newYear = year
       var newMonth = month
       if month <= 2 {
@@ -156,31 +165,53 @@ public enum TinyMoon {
       return Double(c + day + e + f) - 1524.5
     }
 
+    /// Calculates the Julian Day (JD) for a given Date
+    ///
+    /// - Parameters:
+    ///   - date: Any Swift Date to calculate the Julian Day for
+    ///
+    /// - Returns: The Julian Day number, rounded down to four decimal points
+    ///
     /// The Julian Day Count is a uniform count of days from a remote epoch in the past and is used for calculating the days between two events.
+    ///
     /// The Julian day is calculated by combining the contributions from the years, months, and day, taking into account constant offsets and rounding down the result.
     /// https://quasar.as.utexas.edu/BillInfo/JulianDatesG.html
+    /// - Note: Uses hour, minute, and seconds to calculate a precise Julian Day
     internal static func julianDay(_ date: Date) -> Double {
       var calendar = Calendar.current
       calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? calendar.timeZone
       let components = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
 
-      guard let year = components.year, let month = components.month, let day = components.day, let hour = components.hour, let minute = components.minute, let second = components.second else {
+      guard 
+        let year = components.year,
+        let month = components.month,
+        let day = components.day,
+        let hour = components.hour,
+        let minute = components.minute,
+        let second = components.second
+      else {
         fatalError("Could not extract date components")
       }
 
+      /// Used to adjust January and February to be part of the previous year.
+      /// `14` is used to adjust the start of the year to March. Will either be `0` or `1`.
       let a = (14 - month) / 12
+      /// The Julian Day calculation sets year 0 as 4713 BC. 
+      /// To avoid working with negative numbers, `4800` is used as an offset.
       let y = year + 4800 - a
+      /// Adjusts the month for the Julian Day calculation, where March is considered the first month of the year.
       let m = month + 12 * a - 3
 
-      // Calculate Julian Day Number for the date
+      /// Calculate Julian Day Number for the date
+      /// - `153`: A magic number used for month length adjustments.
+      /// - `365`, `4`, `100`, and `400`: These relate to the number of days in a year and the correction for leap years in the Julian and Gregorian calendars.
+      /// `32045` is the correction factor to align the result with the Julian Day Number.
       let jdn = Double(day) + Double((153 * m + 2) / 5) + Double(y) * 365 + Double(y / 4) - Double(y / 100) + Double(y / 400) - 32045
 
-      // Calculate the fraction of the day
+      /// Calculate the fraction of the day past since midnight
+      ///  `1440` is the number of minutes in a day, and `86400` is the number of seconds in a day
       let dayFraction = (Double(hour) - 12) / 24 + Double(minute) / 1440 + Double(second) / 86400
-
-      // Add the day fraction to the Julian Day Number
       let julianDayWithTime = jdn + dayFraction
-
       let roundedJulianDay = (julianDayWithTime * 10000).rounded() / 10000
 
       return roundedJulianDay

--- a/Tests/TinyMoonTests/MoonTestHelper.swift
+++ b/Tests/TinyMoonTests/MoonTestHelper.swift
@@ -4,22 +4,9 @@ import Foundation
 @testable import TinyMoon
 
 enum MoonTestHelper {
-  private static var dateFormatter: DateFormatter {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy/MM/dd HH:mm"
-    return formatter
-  }
-
-  static func formatDate(year: Int, month: Int, day: Int, hour: Int = 00, minute: Int = 00) -> Date {
-    guard let date = MoonTestHelper.dateFormatter.date(from: "\(year)/\(month)/\(day) \(hour):\(minute)") else {
-      fatalError("Invalid date")
-    }
-    return date
-  }
-
   /// Helper function to return a moon object for a given Date
   static func moonDay(year: Int, month: Int, day: Int) -> TinyMoon.Moon {
-    let date = MoonTestHelper.formatDate(year: year, month: month, day: day)
+    let date = TinyMoon.formatDate(year: year, month: month, day: day)
     let moon = TinyMoon.calculateMoonPhase(date)
     return moon
   }

--- a/Tests/TinyMoonTests/MoonTestHelper.swift
+++ b/Tests/TinyMoonTests/MoonTestHelper.swift
@@ -10,8 +10,8 @@ enum MoonTestHelper {
     return formatter
   }
 
-  static func formatDate(year: Int, month: Int, day: Int) -> Date {
-    guard let date = MoonTestHelper.dateFormatter.date(from: "\(year)/\(month)/\(day) 00:00") else {
+  static func formatDate(year: Int, month: Int, day: Int, hour: Int = 00, minute: Int = 00) -> Date {
+    guard let date = MoonTestHelper.dateFormatter.date(from: "\(year)/\(month)/\(day) \(hour):\(minute)") else {
       fatalError("Invalid date")
     }
     return date

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class TinyMoonTests: XCTestCase {
   func test_tinyMoon_calculateMoonPhase_returnsFullMoon() throws {
-    let date = MoonTestHelper.formatDate(year: 2024, month: 04, day: 23)
+    let date = TinyMoon.formatDate(year: 2024, month: 04, day: 23)
     let moon = TinyMoon.calculateMoonPhase(date)
 
     XCTAssertTrue(moon.isFullMoon())
@@ -13,7 +13,7 @@ final class TinyMoonTests: XCTestCase {
   }
 
   func test_moon_daysTillFullMoon_returnsCorrectDays() throws {
-    let date = MoonTestHelper.formatDate(year: 2024, month: 04, day: 22)
+    let date = TinyMoon.formatDate(year: 2024, month: 04, day: 22)
     let moon = TinyMoon.calculateMoonPhase(date)
 
     XCTAssertFalse(moon.isFullMoon())
@@ -23,12 +23,12 @@ final class TinyMoonTests: XCTestCase {
   }
 
   func test_tinyMoon_calculateMoonPhase_returnsNewMoon() throws {
-    var date = MoonTestHelper.formatDate(year: 2024, month: 11, day: 01)
+    var date = TinyMoon.formatDate(year: 2024, month: 11, day: 01)
     var moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.emoji, "\u{1F311}") // 🌑
     XCTAssertEqual(moon.daysTillNewMoon, 0)
 
-    date = MoonTestHelper.formatDate(year: 2024, month: 12, day: 1)
+    date = TinyMoon.formatDate(year: 2024, month: 12, day: 1)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.emoji, "\u{1F311}") // 🌑
     XCTAssertEqual(moon.daysTillNewMoon, 0)
@@ -64,24 +64,41 @@ final class TinyMoonTests: XCTestCase {
 
   func test_moon_julianDay() {
     // January 6, 2000 @ 00:00:00.0
-    var date = MoonTestHelper.formatDate(year: 2000, month: 01, day: 06)
+    var date = TinyMoon.formatDate(year: 2000, month: 01, day: 06)
     var julianDay = TinyMoon.Moon.julianDay(date)
-    print("newJulianDay: ", julianDay)
     XCTAssertEqual(julianDay, 2451549.5000)
 
     // January 6, 2000 @ 20:00:00.0
-    date = MoonTestHelper.formatDate(year: 2000, month: 01, day: 06, hour: 20, minute: 00)
+    date = TinyMoon.formatDate(year: 2000, month: 01, day: 06, hour: 20, minute: 00)
     julianDay = TinyMoon.Moon.julianDay(date)
     XCTAssertEqual(julianDay, 2451550.3333)
 
     // August 22, 2022 @ 00:00:00.0
-    date = MoonTestHelper.formatDate(year: 2022, month: 08, day: 22, hour: 00, minute: 00)
+    date = TinyMoon.formatDate(year: 2022, month: 08, day: 22, hour: 00, minute: 00)
     julianDay = TinyMoon.Moon.julianDay(date)
     XCTAssertEqual(julianDay, 2459813.5000)
 
     // August 22, 2022 @ 04:05:00.0
-    date = MoonTestHelper.formatDate(year: 2022, month: 08, day: 22, hour: 04, minute: 05)
+    date = TinyMoon.formatDate(year: 2022, month: 08, day: 22, hour: 04, minute: 05)
     julianDay = TinyMoon.Moon.julianDay(date)
     XCTAssertEqual(julianDay, 2459813.6701)
+  }
+
+  func test_moon_notPrecise_julianDay() {
+    // January 6, 2000 @ 00:00:00.0
+    var julianDay = TinyMoon.Moon.julianDay(year: 2000, month: 01, day: 06)
+    XCTAssertEqual(julianDay, 2451549.5)
+
+    // January 6, 2000 @ 20:00:00.0
+    julianDay = TinyMoon.Moon.julianDay(year: 2008, month: 12, day: 06)
+    XCTAssertEqual(julianDay, 2454806.5)
+//
+    // August 22, 2022 @ 00:00:00.0
+    julianDay = TinyMoon.Moon.julianDay(year: 2022, month: 08, day: 22)
+    XCTAssertEqual(julianDay, 2459813.5)
+
+    // August 22, 2022 @ 04:05:00.0
+    julianDay = TinyMoon.Moon.julianDay(year: 2022, month: 08, day: 22)
+    XCTAssertEqual(julianDay, 2459813.5)
   }
 }

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -61,5 +61,27 @@ final class TinyMoonTests: XCTestCase {
       }
     }
   }
-}
 
+  func test_moon_julianDay() {
+    // January 6, 2000 @ 00:00:00.0
+    var date = MoonTestHelper.formatDate(year: 2000, month: 01, day: 06)
+    var julianDay = TinyMoon.Moon.julianDay(date)
+    print("newJulianDay: ", julianDay)
+    XCTAssertEqual(julianDay, 2451549.5000)
+
+    // January 6, 2000 @ 20:00:00.0
+    date = MoonTestHelper.formatDate(year: 2000, month: 01, day: 06, hour: 20, minute: 00)
+    julianDay = TinyMoon.Moon.julianDay(date)
+    XCTAssertEqual(julianDay, 2451550.3333)
+
+    // August 22, 2022 @ 00:00:00.0
+    date = MoonTestHelper.formatDate(year: 2022, month: 08, day: 22, hour: 00, minute: 00)
+    julianDay = TinyMoon.Moon.julianDay(date)
+    XCTAssertEqual(julianDay, 2459813.5000)
+
+    // August 22, 2022 @ 04:05:00.0
+    date = MoonTestHelper.formatDate(year: 2022, month: 08, day: 22, hour: 04, minute: 05)
+    julianDay = TinyMoon.Moon.julianDay(date)
+    XCTAssertEqual(julianDay, 2459813.6701)
+  }
+}

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -84,21 +84,21 @@ final class TinyMoonTests: XCTestCase {
     XCTAssertEqual(julianDay, 2459813.6701)
   }
 
-  func test_moon_notPrecise_julianDay() {
+  func test_moon_lessPreciseJulianDay() {
     // January 6, 2000 @ 00:00:00.0
-    var julianDay = TinyMoon.Moon.julianDay(year: 2000, month: 01, day: 06)
+    var julianDay = TinyMoon.Moon.lessPreciseJulianDay(year: 2000, month: 01, day: 06)
     XCTAssertEqual(julianDay, 2451549.5)
 
-    // January 6, 2000 @ 20:00:00.0
-    julianDay = TinyMoon.Moon.julianDay(year: 2008, month: 12, day: 06)
+    // December 6, 2008 @ @ 00:00:00.0
+    julianDay = TinyMoon.Moon.lessPreciseJulianDay(year: 2008, month: 12, day: 06)
     XCTAssertEqual(julianDay, 2454806.5)
 //
     // August 22, 2022 @ 00:00:00.0
-    julianDay = TinyMoon.Moon.julianDay(year: 2022, month: 08, day: 22)
+    julianDay = TinyMoon.Moon.lessPreciseJulianDay(year: 2022, month: 08, day: 22)
     XCTAssertEqual(julianDay, 2459813.5)
 
-    // August 22, 2022 @ 04:05:00.0
-    julianDay = TinyMoon.Moon.julianDay(year: 2022, month: 08, day: 22)
+    // August 22, 2022 @ 00:00:00.0
+    julianDay = TinyMoon.Moon.lessPreciseJulianDay(year: 2022, month: 08, day: 22)
     XCTAssertEqual(julianDay, 2459813.5)
   }
 }

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -96,9 +96,5 @@ final class TinyMoonTests: XCTestCase {
     // August 22, 2022 @ 00:00:00.0
     julianDay = TinyMoon.Moon.lessPreciseJulianDay(year: 2022, month: 08, day: 22)
     XCTAssertEqual(julianDay, 2459813.5)
-
-    // August 22, 2022 @ 00:00:00.0
-    julianDay = TinyMoon.Moon.lessPreciseJulianDay(year: 2022, month: 08, day: 22)
-    XCTAssertEqual(julianDay, 2459813.5)
   }
 }


### PR DESCRIPTION
Closes #15 

### Problem
The Julian day needs to take in a date's time to calculate a more-accurate Julian Day. Right now it is only accurate up to 24hrs, but not up to the minute.

### Current behavior
The current version does not use hours or minutes to compute the Julian Day, so it will only return up to one decimal point of accuracy.

Now, every calculation ends in `.5`

```swift
TinyMoon.Moon.lessPreciseJulianDay(year: 2000, month: 01, day: 06)
// Output is 2451549.5

// August 22, 2022 @ 00:00:00.0
TinyMoon.Moon.lessPreciseJulianDay(year: 2022, month: 08, day: 22)
// Output is 2459813.5
```

### Expected behavior

The Julian day is calculated by combining the contributions from the years, months, and day, taking into account constant offsets, resulting in a more accurate Julian Day calculation.

```swift
// January 6, 2000 @ 00:00:00.0
var date = TinyMoon.formatDate(year: 2000, month: 01, day: 06, hour: 00, minute: 00)
TinyMoon.Moon.julianDay(date)
// Output is 2451549.5000

// January 6, 2000 @ 20:00:00.0
date = TinyMoon.formatDate(year: 2000, month: 01, day: 06, hour: 20, minute: 00)
TinyMoon.Moon.julianDay(date)
// Output is 2451550.3333

// August 22, 2022 @ 00:00:00.0
date = TinyMoon.formatDate(year: 2022, month: 08, day: 22, hour: 00, minute: 00)
TinyMoon.Moon.julianDay(date)
// Output is 2459813.5000

// August 22, 2022 @ 04:05:00.0
date = TinyMoon.formatDate(year: 2022, month: 08, day: 22, hour: 04, minute: 05)
TinyMoon.Moon.julianDay(date)
// Output is 2459813.6701
```

### Central date formatter
Also adding a central date formatter to TinyMoon and using UTC everywhere, to help standardize time and date calcuations

```swift
TinyMoon {
  private static var dateFormatter: DateFormatter {
    let formatter = DateFormatter()
    formatter.dateFormat = "yyyy/MM/dd HH:mm"
    formatter.timeZone = TimeZone(identifier: "UTC")
    return formatter
  }

  static func formatDate(
    year: Int,
    month: Int,
    day: Int,
    hour: Int = 00,
    minute: Int = 00) -> Date
  {
    guard let date = TinyMoon.dateFormatter.date(from: "\(year)/\(month)/\(day) \(hour):\(minute)") else {
      fatalError("Invalid date")
    }
    return date
  }
}
```