### PR TITLE
Add UTC tests for main moon phases

### DIFF
--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -92,7 +92,7 @@ final class TinyMoonTests: XCTestCase {
     // December 6, 2008 @ @ 00:00:00.0
     julianDay = TinyMoon.Moon.lessPreciseJulianDay(year: 2008, month: 12, day: 06)
     XCTAssertEqual(julianDay, 2454806.5)
-//
+
     // August 22, 2022 @ 00:00:00.0
     julianDay = TinyMoon.Moon.lessPreciseJulianDay(year: 2022, month: 08, day: 22)
     XCTAssertEqual(julianDay, 2459813.5)

--- a/Tests/TinyMoonTests/UTCTests.swift
+++ b/Tests/TinyMoonTests/UTCTests.swift
@@ -20,6 +20,9 @@ final class UTCTests: XCTestCase {
   // MARK: New Moon
 
   func tinyMoon_calculateMoonPhase_newMoonPhase_UTC_2024() {
+    var correct = 0.0
+    var incorrect = 0.0
+
     let newMoonEmoji = TinyMoon.MoonPhase.newMoon.emoji
 
     var date = TinyMoon.formatDate(year: 2024, month: 01, day: 11)
@@ -27,149 +30,184 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
+    if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 02, day: 09)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
+    if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 03, day: 10)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
+    if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 04, day: 08)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
+    if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 05, day: 08)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
+    if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 06, day: 06)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
+    if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 07, day: 05)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
+    if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 08, day: 04)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
+    if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 09, day: 03)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
+    if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 02)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
+    if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 01)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
+    if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 12, day: 01)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
+    if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 12, day: 30)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
+    if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
+
+    printResults(.newMoon, correct: correct, incorrect: incorrect)
   }
 
   // MARK: First Quarter
 
   func tinyMoon_calculateMoonPhase_firstQuarterPhase_UTC_2024() {
+    var correct = 0.0
+    var incorrect = 0.0
+
     let firstQuarterEmoji = TinyMoon.MoonPhase.firstQuarter.emoji
 
     var date = TinyMoon.formatDate(year: 2024, month: 01, day: 18)
     var moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+    if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 02, day: 16)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+    if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 03, day: 17)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+    if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 04, day: 15)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+    if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 05, day: 15)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+    if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 06, day: 14)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+    if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 07, day: 13)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+    if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 08, day: 12)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+    if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 09, day: 11)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+    if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 10)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+    if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 09)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+    if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 12, day: 08)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+    if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
+
+    printResults(.firstQuarter, correct: correct, incorrect: incorrect)
   }
 
   // MARK: Full Moon
 
   func tinyMoon_calculateMoonPhase_fullMoonPhase_UTC_2024() {
+    var correct = 0.0
+    var incorrect = 0.0
+
     let fullMoonEmoji = TinyMoon.MoonPhase.fullMoon.emoji
 
     var date = TinyMoon.formatDate(year: 2024, month: 01, day: 25)
@@ -177,143 +215,186 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 02, day: 24)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 03, day: 25)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 04, day: 23)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 05, day: 23)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 06, day: 22)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 07, day: 21)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 08, day: 19)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 09, day: 18)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 17)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 15)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 12, day: 15)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
+
+    printResults(.fullMoon, correct: correct, incorrect: incorrect)
   }
 
   // MARK: Last Quarter
 
   func tinyMoon_calculateMoonPhase_lastQuarterPhase_UTC_2024() {
+    var correct = 0.0
+    var incorrect = 0.0
+
     let lastQuarterEmoji = TinyMoon.MoonPhase.lastQuarter.emoji
 
     var date = TinyMoon.formatDate(year: 2024, month: 01, day: 04)
     var moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+    if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 02, day: 02)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+    if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 03, day: 03)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+    if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 04, day: 02)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+    if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 05, day: 01)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+    if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 05, day: 30)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+    if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 06, day: 28)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+    if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 07, day: 28)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+    if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 08, day: 26)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+    if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 09, day: 24)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+    if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 24)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+    if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 23)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+    if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 12, day: 22)
     moon = TinyMoon.calculateMoonPhase(date)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+    if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
+
+    printResults(.lastQuarter, correct: correct, incorrect: incorrect)
+  }
+
+  private func printResults(_ moonPhase: TinyMoon.MoonPhase, correct: Double, incorrect: Double) {
+    let results = """
+
+    \(moonPhase)
+      "correct: \(correct)"
+      "incorrect: \(incorrect)"
+      % correct: \((correct / (correct + incorrect) * 100).rounded())%
+    """
+    print(results)
   }
 
 }

--- a/Tests/TinyMoonTests/UTCTests.swift
+++ b/Tests/TinyMoonTests/UTCTests.swift
@@ -1,0 +1,319 @@
+// Created by manny_lopez on 6/1/24.
+// Copyright © 2024 Airbnb Inc. All rights reserved.
+
+import XCTest
+@testable import TinyMoon
+
+final class UTCTests: XCTestCase {
+
+  // MARK: - UTC Tests
+  // https://www.timeanddate.com/moon/phases/timezone/utc
+  // The following moon phases are the exact times for the four moon phases
+  // (new, first quarter, full, and last quarter),  in UTC, for 2024
+
+  // Using `lessPreciseJulianDay`, there are 21/50 correct phases
+  // Using `julianDay`, the more precise version, there are 20/50
+  // Both julian day functions are both wrong 19 times
+  // https://docs.google.com/spreadsheets/d/1G85YZnu_PK8L03QyIzovKdnBmZSOWF_HzTpPYSqJUcU/edit?usp=sharing
+
+
+  // MARK: New Moon
+
+  func tinyMoon_calculateMoonPhase_newMoonPhase_UTC_2024() {
+    let newMoonEmoji = TinyMoon.MoonPhase.newMoon.emoji
+
+    var date = TinyMoon.formatDate(year: 2024, month: 01, day: 11)
+    var moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .newMoon)
+    XCTAssertEqual(moon.emoji, newMoonEmoji)
+    XCTAssertEqual(moon.daysTillNewMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 02, day: 09)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .newMoon)
+    XCTAssertEqual(moon.emoji, newMoonEmoji)
+    XCTAssertEqual(moon.daysTillNewMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 03, day: 10)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .newMoon)
+    XCTAssertEqual(moon.emoji, newMoonEmoji)
+    XCTAssertEqual(moon.daysTillNewMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 04, day: 08)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .newMoon)
+    XCTAssertEqual(moon.emoji, newMoonEmoji)
+    XCTAssertEqual(moon.daysTillNewMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 05, day: 08)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .newMoon)
+    XCTAssertEqual(moon.emoji, newMoonEmoji)
+    XCTAssertEqual(moon.daysTillNewMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 06)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .newMoon)
+    XCTAssertEqual(moon.emoji, newMoonEmoji)
+    XCTAssertEqual(moon.daysTillNewMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 07, day: 05)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .newMoon)
+    XCTAssertEqual(moon.emoji, newMoonEmoji)
+    XCTAssertEqual(moon.daysTillNewMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 08, day: 04)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .newMoon)
+    XCTAssertEqual(moon.emoji, newMoonEmoji)
+    XCTAssertEqual(moon.daysTillNewMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 09, day: 03)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .newMoon)
+    XCTAssertEqual(moon.emoji, newMoonEmoji)
+    XCTAssertEqual(moon.daysTillNewMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 10, day: 02)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .newMoon)
+    XCTAssertEqual(moon.emoji, newMoonEmoji)
+    XCTAssertEqual(moon.daysTillNewMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 11, day: 01)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .newMoon)
+    XCTAssertEqual(moon.emoji, newMoonEmoji)
+    XCTAssertEqual(moon.daysTillNewMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 12, day: 01)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .newMoon)
+    XCTAssertEqual(moon.emoji, newMoonEmoji)
+    XCTAssertEqual(moon.daysTillNewMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 12, day: 30)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .newMoon)
+    XCTAssertEqual(moon.emoji, newMoonEmoji)
+    XCTAssertEqual(moon.daysTillNewMoon, 0)
+  }
+
+  // MARK: First Quarter
+
+  func tinyMoon_calculateMoonPhase_firstQuarterPhase_UTC_2024() {
+    let firstQuarterEmoji = TinyMoon.MoonPhase.firstQuarter.emoji
+
+    var date = TinyMoon.formatDate(year: 2024, month: 01, day: 18)
+    var moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .firstQuarter)
+    XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 02, day: 16)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .firstQuarter)
+    XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 03, day: 17)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .firstQuarter)
+    XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 04, day: 15)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .firstQuarter)
+    XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 05, day: 15)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .firstQuarter)
+    XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 14)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .firstQuarter)
+    XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 07, day: 13)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .firstQuarter)
+    XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 08, day: 12)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .firstQuarter)
+    XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 09, day: 11)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .firstQuarter)
+    XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 10, day: 10)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .firstQuarter)
+    XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 11, day: 09)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .firstQuarter)
+    XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 12, day: 08)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .firstQuarter)
+    XCTAssertEqual(moon.emoji, firstQuarterEmoji)
+  }
+
+  // MARK: Full Moon
+
+  func tinyMoon_calculateMoonPhase_fullMoonPhase_UTC_2024() {
+    let fullMoonEmoji = TinyMoon.MoonPhase.fullMoon.emoji
+
+    var date = TinyMoon.formatDate(year: 2024, month: 01, day: 25)
+    var moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.emoji, fullMoonEmoji)
+    XCTAssertEqual(moon.daysTillFullMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 02, day: 24)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.emoji, fullMoonEmoji)
+    XCTAssertEqual(moon.daysTillFullMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 03, day: 25)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.emoji, fullMoonEmoji)
+    XCTAssertEqual(moon.daysTillFullMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 04, day: 23)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.emoji, fullMoonEmoji)
+    XCTAssertEqual(moon.daysTillFullMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 05, day: 23)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.emoji, fullMoonEmoji)
+    XCTAssertEqual(moon.daysTillFullMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 22)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.emoji, fullMoonEmoji)
+    XCTAssertEqual(moon.daysTillFullMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 07, day: 21)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.emoji, fullMoonEmoji)
+    XCTAssertEqual(moon.daysTillFullMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 08, day: 19)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.emoji, fullMoonEmoji)
+    XCTAssertEqual(moon.daysTillFullMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 09, day: 18)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.emoji, fullMoonEmoji)
+    XCTAssertEqual(moon.daysTillFullMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 10, day: 17)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.emoji, fullMoonEmoji)
+    XCTAssertEqual(moon.daysTillFullMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 11, day: 15)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.emoji, fullMoonEmoji)
+    XCTAssertEqual(moon.daysTillFullMoon, 0)
+
+    date = TinyMoon.formatDate(year: 2024, month: 12, day: 15)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.emoji, fullMoonEmoji)
+    XCTAssertEqual(moon.daysTillFullMoon, 0)
+  }
+
+  // MARK: Last Quarter
+
+  func tinyMoon_calculateMoonPhase_lastQuarterPhase_UTC_2024() {
+    let lastQuarterEmoji = TinyMoon.MoonPhase.lastQuarter.emoji
+
+    var date = TinyMoon.formatDate(year: 2024, month: 01, day: 04)
+    var moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .lastQuarter)
+    XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 02, day: 02)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .lastQuarter)
+    XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 03, day: 03)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .lastQuarter)
+    XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 04, day: 02)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .lastQuarter)
+    XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 05, day: 01)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .lastQuarter)
+    XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 05, day: 30)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .lastQuarter)
+    XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 28)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .lastQuarter)
+    XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 07, day: 28)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .lastQuarter)
+    XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 08, day: 26)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .lastQuarter)
+    XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 09, day: 24)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .lastQuarter)
+    XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 10, day: 24)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .lastQuarter)
+    XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 11, day: 23)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .lastQuarter)
+    XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+
+    date = TinyMoon.formatDate(year: 2024, month: 12, day: 22)
+    moon = TinyMoon.calculateMoonPhase(date)
+    XCTAssertEqual(moon.moonPhase, .lastQuarter)
+    XCTAssertEqual(moon.emoji, lastQuarterEmoji)
+  }
+
+}


### PR DESCRIPTION
Adding tests for the major moon phases for 2024, in UTC. Taken from https://www.timeanddate.com/moon/phases/timezone/utc

<img width="1155" alt="image" src="https://github.com/mannylopez/TinyMoon/assets/3945073/e17ea202-d78d-47b9-9ff8-e71631f2536e">

### Results so far

**Less precise Julian Day method**

| | correct | incorrect | % correct |
|-|-|-|-|
|newMoon| 7 | 6 | 54%|
|firstQuarter| 2 | 10 | 17%|
|fullMoon| 7 | 5 | 58%|
|lastQuarter| 5 | 8 | 38%|

**More precise Julian Day method**, from https://github.com/mannylopez/TinyMoon/pull/16

| | correct | incorrect | % correct |
|-|-|-|-|
|newMoon| 0 | 13 | 0%|
|firstQuarter| 9 | 3 | 75%|
|fullMoon| 6 | 6 | 50%|
|lastQuarter| 5 | 8 | 38%|
