### PR TITLE
Add astronomical calculations

### DIFF
--- a/Sources/TinyMoon/TinyMoon.swift
+++ b/Sources/TinyMoon/TinyMoon.swift
@@ -257,22 +257,25 @@ public enum TinyMoon {
     /// - Parameters:
     ///   - julianDay: The date in Julian Days
     ///
-    /// - Returns: λ longitude (in degrees), φ latitude (in degrees), and distance (in kilometers)
+    /// - Returns: Tuple with δ declination (in radians), α rightAscension (in radians), and distance (in kilometers)
     ///
     /// Formula based on  https://aa.quae.nl/en/reken/hemelpositie.html#4
     /// and https://github.com/microsoft/AirSim/blob/main/AirLib/include/common/EarthCelestial.hpp#L180
     /// and https://github.com/mourner/suncalc/blob/master/suncalc.js#L186
-    internal static func moonCoordinates(julianDay: Double) -> (longitude: Double, latitude: Double, distance: Double) {
+    internal static func moonCoordinates(julianDay: Double) -> (declination: Double, rightAscension: Double, distance: Double) {
       let daysSinceJ2000 = daysSinceJ2000(from: julianDay)
-      let L = (218.316 + 13.176396 * daysSinceJ2000).truncatingRemainder(dividingBy: 360) // Geocentric ecliptic longitude, in degrees
-      let M = (134.963 + 13.064993 * daysSinceJ2000).truncatingRemainder(dividingBy: 360) // Mean anomaly, in degrees
-      let F = (93.272 + 13.229350 * daysSinceJ2000).truncatingRemainder(dividingBy: 360) // Mean distance of the Moon from its ascending node, in degrees
+      let L = AstronomicalConstant.degreesToRadians(218.316 + 13.176396 * daysSinceJ2000) // Geocentric ecliptic longitude, in radians
+      let M = AstronomicalConstant.degreesToRadians(134.963 + 13.064993 * daysSinceJ2000) // Mean anomaly, in radians
+      let F = AstronomicalConstant.degreesToRadians(93.272 + 13.229350 * daysSinceJ2000) // Mean distance of the Moon from its ascending node, in radians
 
-      let longitude = L + 6.289 * sin(AstronomicalConstant.degreesToRadians(M))                  // λ Geocentric ecliptic longitude, in degrees
-      let latitude = 5.128 * sin(AstronomicalConstant.degreesToRadians(F))                       // φ Geocentric ecliptic latitude, in degrees
-      let distance = (385001 - 20905 * cos(AstronomicalConstant.degreesToRadians(M))).rounded()  // Distance to the Moon, in kilometers
+      let longitude = L + AstronomicalConstant.degreesToRadians(6.289 * sin(M))                  // λ Geocentric ecliptic longitude, in radians
+      let latitude = AstronomicalConstant.degreesToRadians(5.128 * sin(F))                       // φ Geocentric ecliptic latitude, in radians
+      let distance = 385001 - 20905 * cos(M)  // Distance to the Moon, in kilometers
 
-      return (longitude, latitude, distance)
+      let declination = declination(longitude: longitude, latitude: latitude)
+      let rightAscension = rightAscension(longitude: longitude, latitude: latitude)
+
+      return (declination, rightAscension, distance)
     }
 
     // MARK: Solar methods

--- a/Sources/TinyMoon/TinyMoon.swift
+++ b/Sources/TinyMoon/TinyMoon.swift
@@ -207,6 +207,8 @@ public enum TinyMoon {
     // The obliquity of the ecliptic. Value at the beginning of 2000:
     static let e = 23.4397
 
+    static let perihelion = 102.9372
+
     static func degreesToRadians(_ degrees: Double) -> Double {
       degrees * radians
     }
@@ -248,6 +250,8 @@ public enum TinyMoon {
       return atan2(sin(longitude) * cos(e) - tan(latitude) * sin(e), cos(longitude))
     }
 
+    // MARK: Moon methods
+
     /// Get the position of the Moon on a given Julian Day
     ///
     /// - Parameters:
@@ -271,6 +275,8 @@ public enum TinyMoon {
       return (longitude, latitude, distance)
     }
 
+    // MARK: Solar methods
+
     /// The mean anomaly for the sun
     ///
     /// - Parameters:
@@ -278,7 +284,7 @@ public enum TinyMoon {
     ///
     /// - Returns: Mean anomaly for the sun, in radians
     ///
-    /// Formula from https://aa.quae.nl/en/reken/hemelpositie.html#1_1
+    /// Formula based https://aa.quae.nl/en/reken/hemelpositie.html#1_1
     /// https://github.com/microsoft/AirSim/blob/main/AirLib/include/common/EarthCelestial.hpp#L155
     /// and https://github.com/mourner/suncalc/blob/master/suncalc.js#L57
     internal static func solarMeanAnomaly(julianDay: Double) -> Double {
@@ -286,6 +292,23 @@ public enum TinyMoon {
       return AstronomicalConstant.degreesToRadians((357.5291 + 0.9856002 * daysSinceJ2000))
     }
 
+    /// The ecliptic longitude λ [lambda] shows how far the celestial body is from the vernal equinox, measured along the ecliptic
+    ///
+    /// - Parameters:
+    ///   - solarMeanAnomaly: in radians
+    ///
+    /// - Returns: Ecliptic longitude, in radians
+    ///
+    /// Formula based on https://aa.quae.nl/en/reken/hemelpositie.html#1_1
+    /// and https://github.com/microsoft/AirSim/blob/main/AirLib/include/common/EarthCelestial.hpp#L160
+    /// and https://github.com/mourner/suncalc/blob/master/suncalc.js#L59
+    internal static func eclipticLongitude(solarMeanAnomaly: Double) -> Double {
+      let center = degreesToRadians((1.9148 * sin(solarMeanAnomaly) + 0.02 * sin(2 * solarMeanAnomaly) + 0.0003 * sin(3 * solarMeanAnomaly))) // Equation of center
+      let perihelionInRadians = degreesToRadians(perihelion)
+      return solarMeanAnomaly + center + perihelionInRadians + Double.pi
+    }
+
+    // MARK: Julian day methods
 
     /// The number of Julian days since 1 January 2000, 12:00 UTC
     ///

--- a/Sources/TinyMoon/TinyMoon.swift
+++ b/Sources/TinyMoon/TinyMoon.swift
@@ -217,6 +217,25 @@ public enum TinyMoon {
       return roundedJulianDay
     }
 
+    /// Get the position of the Moon on a given Julian Day
+    ///
+    /// Formula from https://aa.quae.nl/en/reken/hemelpositie.html#4
+    ///
+    /// - Returns: Latitude (in degrees), longitude (in degrees), and distance (in kilometers)
+    internal static func moonPosition(julianDay: Double) -> (Double, Double, Double) {
+      let radians = Double.pi / 180
+      let daysSinceJ2000 = daysSinceJ2000(from: julianDay)
+      let L = (218.316 + 13.176396 * daysSinceJ2000).truncatingRemainder(dividingBy: 360) // Geocentric ecliptic longitude, in degrees
+      let M = (134.963 + 13.064993 * daysSinceJ2000).truncatingRemainder(dividingBy: 360) // Mean anomaly, in degrees
+      let F = (93.272 + 13.229350 * daysSinceJ2000).truncatingRemainder(dividingBy: 360) // Mean distance of the Moon from its ascending node, in degrees
+
+      let latitude = L + 6.289 * sin(radians * M)                   // Geocentric ecliptic latitude, in degrees
+      let longitude = 5.128 * sin(radians * F)                      // Geocentric ecliptic longitude, in degrees
+      let distance = (385001 - 20905 * cos(radians * M)).rounded()  // Distance to the Moon, in kilometers
+
+      return (latitude, longitude, distance)
+    }
+
     /// The number of days since 1 January 2000, 12:00 UTC
     ///
     /// `2451545.0` is the Julian date on 1 January 2000, 12:00 UTC, aka J2000.0

--- a/Sources/TinyMoon/TinyMoon.swift
+++ b/Sources/TinyMoon/TinyMoon.swift
@@ -257,7 +257,7 @@ public enum TinyMoon {
     /// - Parameters:
     ///   - julianDay: The date in Julian Days
     ///
-    /// - Returns: λ longitude (in degrees), φ latitude (in degrees),  and distance (in kilometers)
+    /// - Returns: λ longitude (in degrees), φ latitude (in degrees), and distance (in kilometers)
     ///
     /// Formula based on  https://aa.quae.nl/en/reken/hemelpositie.html#4
     /// and https://github.com/microsoft/AirSim/blob/main/AirLib/include/common/EarthCelestial.hpp#L180
@@ -306,6 +306,26 @@ public enum TinyMoon {
       let center = degreesToRadians((1.9148 * sin(solarMeanAnomaly) + 0.02 * sin(2 * solarMeanAnomaly) + 0.0003 * sin(3 * solarMeanAnomaly))) // Equation of center
       let perihelionInRadians = degreesToRadians(perihelion)
       return solarMeanAnomaly + center + perihelionInRadians + Double.pi
+    }
+
+    /// Get the position of the Sun on a given Julian Day
+    ///
+    /// - Parameters:
+    ///   - julianDay: The date in Julian Days
+    ///
+    /// - Returns: Tuple with δ declination (in radians) and α rightAscension (in radians)
+    ///
+    /// Formula from https://aa.quae.nl/en/reken/hemelpositie.html#1
+    /// https://github.com/microsoft/AirSim/blob/main/AirLib/include/common/EarthCelestial.hpp#L167
+    /// and https://github.com/mourner/suncalc/blob/master/suncalc.js#L67
+    internal static func sunCoordinates(julianDay: Double) -> (declination: Double, rightAscension: Double) {
+      let solarMeanAnomaly = solarMeanAnomaly(julianDay: julianDay)
+      let eclipticLongitude = eclipticLongitude(solarMeanAnomaly: solarMeanAnomaly)
+
+      let declination = declination(longitude: eclipticLongitude, latitude: 0)
+      let rightAscension = rightAscension(longitude: eclipticLongitude, latitude: 0)
+
+      return (declination, rightAscension)
     }
 
     // MARK: Julian day methods

--- a/Sources/TinyMoon/TinyMoon.swift
+++ b/Sources/TinyMoon/TinyMoon.swift
@@ -216,6 +216,13 @@ public enum TinyMoon {
 
       return roundedJulianDay
     }
+
+    /// The number of days since 1 January 2000, 12:00 UTC
+    ///
+    /// `2451545.0` is the Julian date on 1 January 2000, 12:00 UTC, aka J2000.0
+    internal static func daysSinceJ2000(from jd: Double) -> Double {
+      jd - 2451545.0
+    }
   }
 
   public enum MoonPhase: String {

--- a/Sources/TinyMoon/TinyMoon.swift
+++ b/Sources/TinyMoon/TinyMoon.swift
@@ -250,10 +250,15 @@ public enum TinyMoon {
 
     /// Get the position of the Moon on a given Julian Day
     ///
-    /// Formula from https://aa.quae.nl/en/reken/hemelpositie.html#4
+    /// - Parameters:
+    ///   - julianDay: The date in Julian Days
     ///
     /// - Returns: λ longitude (in degrees), φ latitude (in degrees),  and distance (in kilometers)
-    internal static func moonPosition(julianDay: Double) -> (longitude: Double, latitude: Double, distance: Double) {
+    ///
+    /// Formula based on  https://aa.quae.nl/en/reken/hemelpositie.html#4
+    /// and https://github.com/microsoft/AirSim/blob/main/AirLib/include/common/EarthCelestial.hpp#L180
+    /// and https://github.com/mourner/suncalc/blob/master/suncalc.js#L186
+    internal static func moonCoordinates(julianDay: Double) -> (longitude: Double, latitude: Double, distance: Double) {
       let daysSinceJ2000 = daysSinceJ2000(from: julianDay)
       let L = (218.316 + 13.176396 * daysSinceJ2000).truncatingRemainder(dividingBy: 360) // Geocentric ecliptic longitude, in degrees
       let M = (134.963 + 13.064993 * daysSinceJ2000).truncatingRemainder(dividingBy: 360) // Mean anomaly, in degrees
@@ -265,6 +270,22 @@ public enum TinyMoon {
 
       return (longitude, latitude, distance)
     }
+
+    /// The mean anomaly for the sun
+    ///
+    /// - Parameters:
+    ///   - julianDay: The date in Julian Days
+    ///
+    /// - Returns: Mean anomaly for the sun, in radians
+    ///
+    /// Formula from https://aa.quae.nl/en/reken/hemelpositie.html#1_1
+    /// https://github.com/microsoft/AirSim/blob/main/AirLib/include/common/EarthCelestial.hpp#L155
+    /// and https://github.com/mourner/suncalc/blob/master/suncalc.js#L57
+    internal static func solarMeanAnomaly(julianDay: Double) -> Double {
+      let daysSinceJ2000 = daysSinceJ2000(from: julianDay)
+      return AstronomicalConstant.degreesToRadians((357.5291 + 0.9856002 * daysSinceJ2000))
+    }
+
 
     /// The number of Julian days since 1 January 2000, 12:00 UTC
     ///

--- a/Sources/TinyMoon/TinyMoon.swift
+++ b/Sources/TinyMoon/TinyMoon.swift
@@ -21,7 +21,7 @@ public enum TinyMoon {
     }
     return date
   }
-  
+
   public static func calculateMoonPhase(_ date: Date = Date()) -> Moon {
     Moon(date: date)
   }
@@ -225,11 +225,27 @@ public enum TinyMoon {
     /// - Returns: Declination, in radians
     ///
     /// Formula based on https://aa.quae.nl/en/reken/hemelpositie.html#1_7
-    /// and https://github.com/mourner/suncalc/blob/master/suncalc.js#L38
+    /// and https://github.com/mourner/suncalc/blob/master/suncalc.js#L39
     /// and https://github.com/microsoft/AirSim/blob/main/AirLib/include/common/EarthCelestial.hpp#L125
     internal static func declination(longitude: Double, latitude: Double) -> Double {
       let e = AstronomicalConstant.degreesToRadians(AstronomicalConstant.e)
       return asin(sin(latitude) * cos(e) + cos(latitude) * sin(e) * sin(longitude))
+    }
+
+    /// α The right ascension shows how far the body is from the vernal equinox, as measured along the celestial equator
+    ///
+    /// - Parameters:
+    ///   - longitude: in radians
+    ///   - latitude: in radians
+    ///
+    /// - Returns: Right ascension, in radians
+    ///
+    /// Formula based on https://aa.quae.nl/en/reken/hemelpositie.html#1_7
+    /// and https://github.com/mourner/suncalc/blob/master/suncalc.js#L38
+    /// and https://github.com/microsoft/AirSim/blob/main/AirLib/include/common/EarthCelestial.hpp#L120
+    internal static func rightAscension(longitude: Double, latitude: Double) -> Double {
+      let e = AstronomicalConstant.degreesToRadians(AstronomicalConstant.e)
+      return atan2(sin(longitude) * cos(e) - tan(latitude) * sin(e), cos(longitude))
     }
 
     /// Get the position of the Moon on a given Julian Day
@@ -250,7 +266,7 @@ public enum TinyMoon {
       return (longitude, latitude, distance)
     }
 
-    /// The number of days since 1 January 2000, 12:00 UTC
+    /// The number of Julian days since 1 January 2000, 12:00 UTC
     ///
     /// `2451545.0` is the Julian date on 1 January 2000, 12:00 UTC, aka J2000.0
     internal static func daysSinceJ2000(from jd: Double) -> Double {

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -100,10 +100,25 @@ final class TinyMoonTests: XCTestCase {
 
   func test_moon_daysSinceJ2000() {
     let date = TinyMoon.formatDate(year: 2004, month: 01, day: 1)
-    let julianDate = TinyMoon.Moon.julianDay(date)
-    XCTAssertEqual(julianDate, 2453005.5000)
+    let julianDay = TinyMoon.Moon.julianDay(date)
+    XCTAssertEqual(julianDay, 2453005.5000)
 
-    let daysSinceJ2000 = TinyMoon.Moon.daysSinceJ2000(from: julianDate)
+    let daysSinceJ2000 = TinyMoon.Moon.daysSinceJ2000(from: julianDay)
     XCTAssertEqual(daysSinceJ2000, 1460.5)
+  }
+
+  func test_moon_moonPosition() {
+    let date = TinyMoon.formatDate(year: 2004, month: 01, day: 1)
+    let julianDay = TinyMoon.Moon.julianDay(date)
+    let (longitude, latitude, distance) = TinyMoon.Moon.moonPosition(julianDay: julianDay)
+
+//    XCTAssertEqual(L, 22.44235800000024)  // 22.44 degrees
+//    XCTAssertEqual(M, 136.38527649999742) // 136.39 degrees
+//    XCTAssertEqual(F, 334.7376750000003)  // 334.74 degrees
+
+    // Test values taken from https://aa.quae.nl/en/reken/hemelpositie.html#4
+    XCTAssertEqual(longitude, 26.78054550631917)
+    XCTAssertEqual(latitude, -2.188442146158122)
+    XCTAssertEqual(distance, 400136)
   }
 }

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -109,7 +109,7 @@ final class TinyMoonTests: XCTestCase {
     XCTAssertEqual(daysSinceJ2000, 1460.5)
   }
 
-  func test_astronomicalConstant_moonPosition() {
+  func test_astronomicalConstant_moonCoordinates() {
     let date = TinyMoon.formatDate(year: 2004, month: 01, day: 1)
     let julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     let moonCoordinates = TinyMoon.AstronomicalConstant.moonCoordinates(julianDay: julianDay)
@@ -159,5 +159,14 @@ final class TinyMoonTests: XCTestCase {
     let solarMeanAnomaly = TinyMoon.AstronomicalConstant.solarMeanAnomaly(julianDay: julianDay)
     let eclipticLongitude = TinyMoon.AstronomicalConstant.eclipticLongitude(solarMeanAnomaly: solarMeanAnomaly)
     XCTAssertEqual(eclipticLongitude, 36.29993339416619)
+  }
+
+  func test_astronomicalConstant_sunCoordinates() {
+    let date = TinyMoon.formatDate(year: 2004, month: 01, day: 1)
+    let julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    let moonCoordinates = TinyMoon.AstronomicalConstant.sunCoordinates(julianDay: julianDay)
+
+    XCTAssertEqual(moonCoordinates.declination, -0.4027395448243531)
+    XCTAssertEqual(moonCoordinates.rightAscension, -1.3840846794023092)
   }
 }

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -97,4 +97,13 @@ final class TinyMoonTests: XCTestCase {
     julianDay = TinyMoon.Moon.lessPreciseJulianDay(year: 2022, month: 08, day: 22)
     XCTAssertEqual(julianDay, 2459813.5)
   }
+
+  func test_moon_daysSinceJ2000() {
+    let date = TinyMoon.formatDate(year: 2004, month: 01, day: 1)
+    let julianDate = TinyMoon.Moon.julianDay(date)
+    XCTAssertEqual(julianDate, 2453005.5000)
+
+    let daysSinceJ2000 = TinyMoon.Moon.daysSinceJ2000(from: julianDate)
+    XCTAssertEqual(daysSinceJ2000, 1460.5)
+  }
 }

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -112,16 +112,16 @@ final class TinyMoonTests: XCTestCase {
   func test_astronomicalConstant_moonPosition() {
     let date = TinyMoon.formatDate(year: 2004, month: 01, day: 1)
     let julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    let moonPosition = TinyMoon.AstronomicalConstant.moonPosition(julianDay: julianDay)
+    let moonCoordinates = TinyMoon.AstronomicalConstant.moonCoordinates(julianDay: julianDay)
 
 //    XCTAssertEqual(L, 22.44235800000024)  // 22.44 degrees
 //    XCTAssertEqual(M, 136.38527649999742) // 136.39 degrees
 //    XCTAssertEqual(F, 334.7376750000003)  // 334.74 degrees
 
     // Test values taken from https://aa.quae.nl/en/reken/hemelpositie.html#4
-    XCTAssertEqual(moonPosition.longitude, 26.78054550631917)
-    XCTAssertEqual(moonPosition.latitude, -2.188442146158122)
-    XCTAssertEqual(moonPosition.distance, 400136)
+    XCTAssertEqual(moonCoordinates.longitude, 26.78054550631917)
+    XCTAssertEqual(moonCoordinates.latitude, -2.188442146158122)
+    XCTAssertEqual(moonCoordinates.distance, 400136)
   }
 
   func test_astronomicalConstant_declination() {
@@ -144,5 +144,12 @@ final class TinyMoonTests: XCTestCase {
     XCTAssertEqual(rightAscension, TinyMoon.AstronomicalConstant.degreesToRadians(170.20), accuracy: 0.0015)
 
     XCTAssertEqual(rightAscension, 2.969160475404514)
+  }
+
+  func test_astronomicalConstant_solarMeanAnomaly() {
+    let date = TinyMoon.formatDate(year: 2004, month: 01, day: 1)
+    let julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    let solarMeanAnomaly = TinyMoon.AstronomicalConstant.solarMeanAnomaly(julianDay: julianDay)
+    XCTAssertEqual(solarMeanAnomaly, 31.363535104530555)
   }
 }

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -114,14 +114,17 @@ final class TinyMoonTests: XCTestCase {
     let julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     let moonCoordinates = TinyMoon.AstronomicalConstant.moonCoordinates(julianDay: julianDay)
 
-//    XCTAssertEqual(L, 22.44235800000024)  // 22.44 degrees
-//    XCTAssertEqual(M, 136.38527649999742) // 136.39 degrees
-//    XCTAssertEqual(F, 334.7376750000003)  // 334.74 degrees
-
     // Test values taken from https://aa.quae.nl/en/reken/hemelpositie.html#4
-    XCTAssertEqual(moonCoordinates.longitude, 26.78054550631917)
-    XCTAssertEqual(moonCoordinates.latitude, -2.188442146158122)
-    XCTAssertEqual(moonCoordinates.distance, 400136)
+//    XCTAssertEqual(moonCoordinates.L, 339.683699626709)  // 22.44 degrees
+//    XCTAssertEqual(moonCoordinates.M, 335.3891934066859) // 136.39 degrees
+//    XCTAssertEqual(moonCoordinates.F, 338.8510958397388)  // 334.74 degrees
+//
+//    XCTAssertEqual(moonCoordinates.longitude, 339.7594152822631) // 0.46740869456428196793
+//    XCTAssertEqual(moonCoordinates.latitude, -0.038195520939872045) // -0.038195520939775448599
+
+    XCTAssertEqual(moonCoordinates.declination, 0.14456842408751425)
+    XCTAssertEqual(moonCoordinates.rightAscension, 0.4475918797699177)
+    XCTAssertEqual(moonCoordinates.distance, 400136.10760520655)
   }
 
   func test_astronomicalConstant_declination() {

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -130,9 +130,19 @@ final class TinyMoonTests: XCTestCase {
     let latitude = TinyMoon.AstronomicalConstant.degreesToRadians(1.208)
     let declination = TinyMoon.AstronomicalConstant.declination(longitude: longitude, latitude: latitude)
 
-    let tolerance = 1e-5
-    XCTAssertTrue(abs(declination - TinyMoon.AstronomicalConstant.degreesToRadians(5.567)) < tolerance)
+    XCTAssertEqual(declination, TinyMoon.AstronomicalConstant.degreesToRadians(5.567), accuracy: 1e-5)
 
-    XCTAssertEqual(declination, 0.09717015472346271)
+    XCTAssertEqual(declination, 0.09717015472346271, accuracy: 1e-5)
+  }
+
+  func test_astronomicalConstant_rightAscension() {
+    // Test values taken from https://aa.quae.nl/en/reken/hemelpositie.html#1_7
+    let longitude = TinyMoon.AstronomicalConstant.degreesToRadians(168.737)
+    let latitude = TinyMoon.AstronomicalConstant.degreesToRadians(1.208)
+    let rightAscension = TinyMoon.AstronomicalConstant.rightAscension(longitude: longitude, latitude: latitude)
+
+    XCTAssertEqual(rightAscension, TinyMoon.AstronomicalConstant.degreesToRadians(170.20), accuracy: 0.0015)
+
+    XCTAssertEqual(rightAscension, 2.969160475404514)
   }
 }

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -62,63 +62,77 @@ final class TinyMoonTests: XCTestCase {
     }
   }
 
+  // MARK: - AstronomicalConstant tests
+
   func test_moon_julianDay() {
     // January 6, 2000 @ 00:00:00.0
     var date = TinyMoon.formatDate(year: 2000, month: 01, day: 06)
-    var julianDay = TinyMoon.Moon.julianDay(date)
+    var julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     XCTAssertEqual(julianDay, 2451549.5000)
 
     // January 6, 2000 @ 20:00:00.0
     date = TinyMoon.formatDate(year: 2000, month: 01, day: 06, hour: 20, minute: 00)
-    julianDay = TinyMoon.Moon.julianDay(date)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     XCTAssertEqual(julianDay, 2451550.3333)
 
     // August 22, 2022 @ 00:00:00.0
     date = TinyMoon.formatDate(year: 2022, month: 08, day: 22, hour: 00, minute: 00)
-    julianDay = TinyMoon.Moon.julianDay(date)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     XCTAssertEqual(julianDay, 2459813.5000)
 
     // August 22, 2022 @ 04:05:00.0
     date = TinyMoon.formatDate(year: 2022, month: 08, day: 22, hour: 04, minute: 05)
-    julianDay = TinyMoon.Moon.julianDay(date)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     XCTAssertEqual(julianDay, 2459813.6701)
   }
 
   func test_moon_lessPreciseJulianDay() {
     // January 6, 2000 @ 00:00:00.0
-    var julianDay = TinyMoon.Moon.lessPreciseJulianDay(year: 2000, month: 01, day: 06)
+    var julianDay = TinyMoon.AstronomicalConstant.lessPreciseJulianDay(year: 2000, month: 01, day: 06)
     XCTAssertEqual(julianDay, 2451549.5)
 
     // December 6, 2008 @ @ 00:00:00.0
-    julianDay = TinyMoon.Moon.lessPreciseJulianDay(year: 2008, month: 12, day: 06)
+    julianDay = TinyMoon.AstronomicalConstant.lessPreciseJulianDay(year: 2008, month: 12, day: 06)
     XCTAssertEqual(julianDay, 2454806.5)
 
     // August 22, 2022 @ 00:00:00.0
-    julianDay = TinyMoon.Moon.lessPreciseJulianDay(year: 2022, month: 08, day: 22)
+    julianDay = TinyMoon.AstronomicalConstant.lessPreciseJulianDay(year: 2022, month: 08, day: 22)
     XCTAssertEqual(julianDay, 2459813.5)
   }
 
-  func test_moon_daysSinceJ2000() {
+  func test_astronomicalConstant_daysSinceJ2000() {
     let date = TinyMoon.formatDate(year: 2004, month: 01, day: 1)
-    let julianDay = TinyMoon.Moon.julianDay(date)
+    let julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     XCTAssertEqual(julianDay, 2453005.5000)
 
-    let daysSinceJ2000 = TinyMoon.Moon.daysSinceJ2000(from: julianDay)
+    let daysSinceJ2000 = TinyMoon.AstronomicalConstant.daysSinceJ2000(from: julianDay)
     XCTAssertEqual(daysSinceJ2000, 1460.5)
   }
 
-  func test_moon_moonPosition() {
+  func test_astronomicalConstant_moonPosition() {
     let date = TinyMoon.formatDate(year: 2004, month: 01, day: 1)
-    let julianDay = TinyMoon.Moon.julianDay(date)
-    let (longitude, latitude, distance) = TinyMoon.Moon.moonPosition(julianDay: julianDay)
+    let julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    let moonPosition = TinyMoon.AstronomicalConstant.moonPosition(julianDay: julianDay)
 
 //    XCTAssertEqual(L, 22.44235800000024)  // 22.44 degrees
 //    XCTAssertEqual(M, 136.38527649999742) // 136.39 degrees
 //    XCTAssertEqual(F, 334.7376750000003)  // 334.74 degrees
 
     // Test values taken from https://aa.quae.nl/en/reken/hemelpositie.html#4
-    XCTAssertEqual(longitude, 26.78054550631917)
-    XCTAssertEqual(latitude, -2.188442146158122)
-    XCTAssertEqual(distance, 400136)
+    XCTAssertEqual(moonPosition.longitude, 26.78054550631917)
+    XCTAssertEqual(moonPosition.latitude, -2.188442146158122)
+    XCTAssertEqual(moonPosition.distance, 400136)
+  }
+
+  func test_astronomicalConstant_declination() {
+    // Test values taken from https://aa.quae.nl/en/reken/hemelpositie.html#1_7
+    let longitude = TinyMoon.AstronomicalConstant.degreesToRadians(168.737)
+    let latitude = TinyMoon.AstronomicalConstant.degreesToRadians(1.208)
+    let declination = TinyMoon.AstronomicalConstant.declination(longitude: longitude, latitude: latitude)
+
+    let tolerance = 1e-5
+    XCTAssertTrue(abs(declination - TinyMoon.AstronomicalConstant.degreesToRadians(5.567)) < tolerance)
+
+    XCTAssertEqual(declination, 0.09717015472346271)
   }
 }

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -152,4 +152,12 @@ final class TinyMoonTests: XCTestCase {
     let solarMeanAnomaly = TinyMoon.AstronomicalConstant.solarMeanAnomaly(julianDay: julianDay)
     XCTAssertEqual(solarMeanAnomaly, 31.363535104530555)
   }
+
+  func test_astronomicalConstant_eclipticLongitude() {
+    let date = TinyMoon.formatDate(year: 2004, month: 01, day: 1)
+    let julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    let solarMeanAnomaly = TinyMoon.AstronomicalConstant.solarMeanAnomaly(julianDay: julianDay)
+    let eclipticLongitude = TinyMoon.AstronomicalConstant.eclipticLongitude(solarMeanAnomaly: solarMeanAnomaly)
+    XCTAssertEqual(eclipticLongitude, 36.29993339416619)
+  }
 }

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -172,4 +172,42 @@ final class TinyMoonTests: XCTestCase {
     XCTAssertEqual(moonCoordinates.declination, -0.4027395448243531)
     XCTAssertEqual(moonCoordinates.rightAscension, -1.3840846794023092)
   }
+
+  func test_astronomicalConstant_getMoonPhase() {
+    // Full moon
+    var date = TinyMoon.formatDate(year: 2024, month: 06, day: 22)
+    var julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    var moonPhase = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay)
+
+    XCTAssertEqual(moonPhase.illuminatedFraction, 0.9978874952116796)
+    XCTAssertEqual(moonPhase.phase, 0.4853646873327652)
+    XCTAssertEqual(moonPhase.angle, -2.87048004074093)
+
+    // New moon
+    date = TinyMoon.formatDate(year: 2024, month: 07, day: 06, hour: 12, minute: 37)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    moonPhase = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay)
+
+    XCTAssertEqual(moonPhase.illuminatedFraction, 0.0074256887778501035)
+    XCTAssertEqual(moonPhase.phase, 0.027463599533906702)
+    XCTAssertEqual(moonPhase.angle, -1.9356269936608987)
+
+    // First quarter
+    date = TinyMoon.formatDate(year: 2024, month: 08, day: 12, hour: 15, minute: 18)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    moonPhase = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay)
+
+    XCTAssertEqual(moonPhase.illuminatedFraction, 0.5105142058965426)
+    XCTAssertEqual(moonPhase.phase, 0.25334702238541357)
+    XCTAssertEqual(moonPhase.angle, -1.2995626391218953)
+
+    // Last quarter
+    date = TinyMoon.formatDate(year: 2024, month: 08, day: 26, hour: 09, minute: 25)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    moonPhase = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay)
+
+    XCTAssertEqual(moonPhase.illuminatedFraction, 0.5115277719739029)
+    XCTAssertEqual(moonPhase.phase, 0.7463302710536945)
+    XCTAssertEqual(moonPhase.angle, 1.3632143802303285)
+  }
 }


### PR DESCRIPTION
Closes #6 #11

Based on
- https://aa.quae.nl/en/reken/hemelpositie.html and
- https://github.com/mourner/suncalc which looks to be based off of https://github.com/microsoft/AirSim/blob/main/AirLib/include/common/EarthCelestial.hpp

### AstronomicalConstant
- Add a new namespace, `AstronomicalConstant`, for all astronomical calculations
- Add `getMoonPhase` and supporting functions
  - degreesToRadians
  - radiansToDegrees
  - declination
  - rightAscension
  - moonCoordinates
  - solarMeanAnomaly
  - eclipticLongitude
  - sunCoordinates
  - daysSinceJ2000
- Add tests for all methods
- Document all methods