### PR TITLE
Add timezone support

### DIFF
--- a/Sources/TinyMoon/TinyMoon+AstronomicalConstant.swift
+++ b/Sources/TinyMoon/TinyMoon+AstronomicalConstant.swift
@@ -259,9 +259,7 @@ extension TinyMoon {
       ///  `1440` is the number of minutes in a day, and `86400` is the number of seconds in a day
       let dayFraction = (Double(hour) - 12) / 24 + Double(minute) / 1440 + Double(second) / 86400
       let julianDayWithTime = jdn + dayFraction
-      let roundedJulianDay = (julianDayWithTime * 10000).rounded() / 10000
-
-      return roundedJulianDay
+      return (julianDayWithTime * 10000).rounded() / 10000
     }
   }
 }

--- a/Sources/TinyMoon/TinyMoon+Moon.swift
+++ b/Sources/TinyMoon/TinyMoon+Moon.swift
@@ -200,7 +200,8 @@ extension TinyMoon {
     ///
     /// ```swift
     /// let date = Date()
-    /// let (start, end) = julianStartAndEndOfDay(date: date)
+    /// let utcTimeZone = TimeZone(identifier: "UTC")!
+    /// let (start, end) = julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
     /// print(start)
     /// // 2460586.5  = October 3, 2024 at 00:00 UTC
     /// print(end)

--- a/Sources/TinyMoon/TinyMoon+Moon.swift
+++ b/Sources/TinyMoon/TinyMoon+Moon.swift
@@ -281,13 +281,13 @@ extension TinyMoon {
 
     static func minorMoonPhase(phaseFraction: Double) -> MoonPhase {
       if phaseFraction < 0.25 {
-        return .waxingCrescent
+        .waxingCrescent
       } else if phaseFraction < 0.50 {
-        return .waxingGibbous
+        .waxingGibbous
       } else if phaseFraction < 0.75 {
-        return .waningGibbous
+        .waningGibbous
       } else {
-        return .waningCrescent
+        .waningCrescent
       }
     }
 

--- a/Sources/TinyMoon/TinyMoon+Moon.swift
+++ b/Sources/TinyMoon/TinyMoon+Moon.swift
@@ -280,16 +280,14 @@ extension TinyMoon {
     }
 
     static func minorMoonPhase(phaseFraction: Double) -> MoonPhase {
-      if phaseFraction < 0.23 {
-        .waxingCrescent
-      } else if phaseFraction < 0.48 {
-        .waxingGibbous
-      } else if phaseFraction < 0.73 {
-        .waningGibbous
-      } else if phaseFraction < 0.98 {
-        .waningCrescent
+      if phaseFraction < 0.25 {
+        return .waxingCrescent
+      } else if phaseFraction < 0.50 {
+        return .waxingGibbous
+      } else if phaseFraction < 0.75 {
+        return .waningGibbous
       } else {
-        .newMoon
+        return .waningCrescent
       }
     }
 

--- a/Sources/TinyMoon/TinyMoon.swift
+++ b/Sources/TinyMoon/TinyMoon.swift
@@ -13,8 +13,8 @@ public enum TinyMoon {
   /// If no major moon phase occurs within the date's 24 hours (starting at 00:00 and ending at 23:59), the object will represent the moon phase closest to the specified date and time.
   ///
   /// - Note: Unlike `ExactMoon`, this object will prioritize major moon phases occurring at any point within a 24-hour period.
-  public static func calculateMoonPhase(_ date: Date = Date()) -> Moon {
-    Moon(date: date)
+  public static func calculateMoonPhase(_ date: Date = Date(), timeZone: TimeZone = TimeZone.current) -> Moon {
+    Moon(date: date, timeZone: timeZone)
   }
 
   /// The `ExactMoon` object for a specific date and time.
@@ -33,27 +33,42 @@ public enum TinyMoon {
 
   // MARK: Internal
 
+  enum TimeZoneOption {
+    case utc
+    case pacific
+    case tokyo
+
+    static func createTimeZone(timeZone: TimeZoneOption) -> TimeZone {
+      switch timeZone {
+      case .utc:
+        TimeZone(identifier: "UTC")!
+      case .pacific:
+        TimeZone(identifier: "America/Los_Angeles")!
+      case .tokyo:
+        TimeZone(identifier: "Asia/Tokyo")!
+      }
+    }
+  }
+
+  /// Creates a Date from the given arguments. Default is in UTC timezone.
   static func formatDate(
     year: Int,
     month: Int,
     day: Int,
     hour: Int = 00,
-    minute: Int = 00)
+    minute: Int = 00,
+    timeZone: TimeZone = TimeZoneOption.createTimeZone(timeZone: .utc))
     -> Date
   {
-    guard let date = TinyMoon.dateFormatter.date(from: "\(year)/\(month)/\(day) \(hour):\(minute)") else {
-      fatalError("Invalid date")
-    }
-    return date
-  }
+    var components = DateComponents()
+    components.year = year
+    components.month = month
+    components.day = day
+    components.hour = hour
+    components.minute = minute
+    components.timeZone = timeZone
 
-  // MARK: Private
-
-  private static var dateFormatter: DateFormatter {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy/MM/dd HH:mm"
-    formatter.timeZone = TimeZone(identifier: "UTC")
-    return formatter
+    return Calendar.current.date(from: components)!
   }
 
 }

--- a/Tests/TinyMoonTests/Helpers/MoonTestHelper.swift
+++ b/Tests/TinyMoonTests/Helpers/MoonTestHelper.swift
@@ -60,8 +60,9 @@ enum MoonTestHelper {
 // MARK: - MoonTestHelper + Pretty print for debugging convenience methods
 
 extension MoonTestHelper {
-  static func prettyPrintMoonCalendar(month: MonthTestHelper.Month, year: Int) {
-    let calendar = Calendar.current
+  static func prettyPrintMoonCalendar(month: MonthTestHelper.Month, year: Int, timeZone: TimeZone = utcTimeZone) {
+    var calendar = Calendar.current
+    calendar.timeZone = timeZone
     let dateFormatter = DateFormatter()
     dateFormatter.dateFormat = "yyyy-MM-dd"
 
@@ -79,7 +80,7 @@ extension MoonTestHelper {
     }
 
     // Prepare an array to hold all moon objects for the month
-    let moonObjects = moonObjectsForMonth(month: month, year: year)
+    let moonObjects = moonObjectsForMonth(month: month, year: year, timeZone: timeZone)
 
     // Calculate padding for the start of the month
     let padding = weekday - 1 // Calendar component weekday starts at 1 for Sunday

--- a/Tests/TinyMoonTests/Helpers/MoonTestHelper.swift
+++ b/Tests/TinyMoonTests/Helpers/MoonTestHelper.swift
@@ -6,30 +6,50 @@ import Foundation
 // MARK: - MoonTestHelper
 
 enum MoonTestHelper {
+  static let utcTimeZone = TimeZone(identifier: "UTC")!
+
   /// Helper function to return a moon object for a given Date
-  static func moonObjectForDay(year: Int, month: Int, day: Int, hour: Int = 0, minute: Int = 0) -> TinyMoon.Moon {
-    let date = TinyMoon.formatDate(year: year, month: month, day: day, hour: hour, minute: minute)
-    let moon = TinyMoon.calculateMoonPhase(date)
-    return moon
+  static func moonObjectForDay(
+    year: Int,
+    month: Int,
+    day: Int,
+    hour: Int = 0,
+    minute: Int = 0,
+    timeZone: TimeZone = utcTimeZone)
+    -> TinyMoon.Moon
+  {
+    let date = TinyMoon.formatDate(year: year, month: month, day: day, hour: hour, minute: minute, timeZone: timeZone)
+    return TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
   }
 
   /// Helper function to return an array of moon objects for a given range of Dates
-  static func moonObjectsForRange(year: Int, month: Int, days: ClosedRange<Int>) -> [TinyMoon.Moon] {
+  static func moonObjectsForRange(
+    year: Int,
+    month: Int,
+    days: ClosedRange<Int>,
+    timeZone: TimeZone = utcTimeZone)
+    -> [TinyMoon.Moon]
+  {
     var moons: [TinyMoon.Moon] = []
 
     moons = days.map { day in
-      moonObjectForDay(year: year, month: month, day: day)
+      moonObjectForDay(year: year, month: month, day: day, timeZone: timeZone)
     }
 
     return moons
   }
 
   /// Helper function to return a full month's moon objects
-  static func moonObjectsForMonth(month: MonthTestHelper.Month, year: Int) -> [TinyMoon.Moon] {
+  static func moonObjectsForMonth(
+    month: MonthTestHelper.Month,
+    year: Int,
+    timeZone: TimeZone = utcTimeZone)
+    -> [TinyMoon.Moon]
+  {
     var moons: [TinyMoon.Moon] = []
 
     MonthTestHelper.dayRangeInMonth(month, year: year)?.forEach { day in
-      moons.append(moonObjectForDay(year: year, month: month.rawValue, day: day))
+      moons.append(moonObjectForDay(year: year, month: month.rawValue, day: day, timeZone: timeZone))
     }
 
     return moons
@@ -204,8 +224,8 @@ extension MoonTestHelper {
   ///   - illuminatedFraction: 0.9014349660199269
   ///   - daysTillFullMoon: 26
   ///   - daysTillNewMoon: 11
-  static func prettyPrintMoonObjectsForMonth(month: MonthTestHelper.Month, year: Int) {
-    let moons = moonObjectsForMonth(month: month, year: year)
+  static func prettyPrintMoonObjectsForMonth(month: MonthTestHelper.Month, year: Int, timeZone: TimeZone = utcTimeZone) {
+    let moons = moonObjectsForMonth(month: month, year: year, timeZone: timeZone)
     for moon in moons {
       MoonTestHelper.prettyPrintMoonObject(moon)
     }

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -171,90 +171,82 @@ final class TinyMoonTests: XCTestCase {
   }
 
   func test_moon_startAndEndOfJulianDay() {
-    var date = TinyMoon.formatDate(year: 2024, month: 01, day: 11, hour: 00)
-    var julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    var beginningAndEndJulianDays = TinyMoon.Moon.startAndEndOfJulianDay(julianDay: julianDay)
-    XCTAssertEqual(beginningAndEndJulianDays.start, 2460320.5)
-    XCTAssertEqual(beginningAndEndJulianDays.end, 2460321.4993)
+    let utcTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
 
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 11, hour: 06)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    beginningAndEndJulianDays = TinyMoon.Moon.startAndEndOfJulianDay(julianDay: julianDay)
-    XCTAssertEqual(beginningAndEndJulianDays.start, 2460320.5)
-    XCTAssertEqual(beginningAndEndJulianDays.end, 2460321.4993)
+    var date = TinyMoon.formatDate(year: 2024, month: 01, day: 11, hour: 00, timeZone: utcTimeZone)
+    var (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(start, 2460320.5)
+    XCTAssertEqual(end, 2460321.5)
 
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 11, hour: 09)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    beginningAndEndJulianDays = TinyMoon.Moon.startAndEndOfJulianDay(julianDay: julianDay)
-    XCTAssertEqual(beginningAndEndJulianDays.start, 2460320.5)
-    XCTAssertEqual(beginningAndEndJulianDays.end, 2460321.4993)
+    date = TinyMoon.formatDate(year: 2024, month: 01, day: 11, hour: 06, timeZone: utcTimeZone)
+    (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(start, 2460320.5)
+    XCTAssertEqual(end, 2460321.5)
 
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 11, hour: 12)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    beginningAndEndJulianDays = TinyMoon.Moon.startAndEndOfJulianDay(julianDay: julianDay)
-    XCTAssertEqual(beginningAndEndJulianDays.start, 2460320.5)
-    XCTAssertEqual(beginningAndEndJulianDays.end, 2460321.4993)
+    date = TinyMoon.formatDate(year: 2024, month: 01, day: 11, hour: 09, timeZone: utcTimeZone)
+    (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(start, 2460320.5)
+    XCTAssertEqual(end, 2460321.5)
 
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 11, hour: 23, minute: 18)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    beginningAndEndJulianDays = TinyMoon.Moon.startAndEndOfJulianDay(julianDay: julianDay)
-    XCTAssertEqual(beginningAndEndJulianDays.start, 2460320.5)
-    XCTAssertEqual(beginningAndEndJulianDays.end, 2460321.4993)
+    date = TinyMoon.formatDate(year: 2024, month: 01, day: 11, hour: 12, timeZone: utcTimeZone)
+    (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(start, 2460320.5)
+    XCTAssertEqual(end, 2460321.5)
 
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 12, hour: 05)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    beginningAndEndJulianDays = TinyMoon.Moon.startAndEndOfJulianDay(julianDay: julianDay)
-    XCTAssertEqual(beginningAndEndJulianDays.start, 2460321.5)
-    XCTAssertEqual(beginningAndEndJulianDays.end, 2460322.4993)
+    date = TinyMoon.formatDate(year: 2024, month: 01, day: 11, hour: 23, minute: 18, timeZone: utcTimeZone)
+    (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(start, 2460320.5)
+    XCTAssertEqual(end, 2460321.5)
+
+    date = TinyMoon.formatDate(year: 2024, month: 01, day: 12, hour: 05, timeZone: utcTimeZone)
+    (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(start, 2460321.5)
+    XCTAssertEqual(end, 2460322.5)
   }
 
   func test_moon_majorMoonPhaseInRange() throws {
+    let utcTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
+
     // Full Moon
-    var date = TinyMoon.formatDate(year: 2024, month: 04, day: 23)
-    var julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    var beginningAndEndJulianDays = TinyMoon.Moon.startAndEndOfJulianDay(julianDay: julianDay)
-    var startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: beginningAndEndJulianDays.start).phase
-    var endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: beginningAndEndJulianDays.end).phase
+    var date = TinyMoon.formatDate(year: 2024, month: 04, day: 23, timeZone: utcTimeZone)
+    var (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
+    var startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: start).phase
+    var endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: end).phase
     XCTAssertNil(TinyMoon.Moon.majorMoonPhaseInRange(start: startMoonPhaseFraction, end: endMoonPhaseFraction))
 
-    date = TinyMoon.formatDate(year: 2024, month: 04, day: 24)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    beginningAndEndJulianDays = TinyMoon.Moon.startAndEndOfJulianDay(julianDay: julianDay)
-    startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: beginningAndEndJulianDays.start).phase
-    endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: beginningAndEndJulianDays.end).phase
+    date = TinyMoon.formatDate(year: 2024, month: 04, day: 24, timeZone: utcTimeZone)
+    (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
+    startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: start).phase
+    endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: end).phase
     var fullMoon = try XCTUnwrap(TinyMoon.Moon.majorMoonPhaseInRange(start: startMoonPhaseFraction, end: endMoonPhaseFraction))
     XCTAssertEqual(fullMoon, .fullMoon)
 
     // Full Moon
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 25)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    beginningAndEndJulianDays = TinyMoon.Moon.startAndEndOfJulianDay(julianDay: julianDay)
-    startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: beginningAndEndJulianDays.start).phase
-    endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: beginningAndEndJulianDays.end).phase
+    date = TinyMoon.formatDate(year: 2024, month: 01, day: 25, timeZone: utcTimeZone)
+    (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
+    startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: start).phase
+    endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: end).phase
     fullMoon = try XCTUnwrap(TinyMoon.Moon.majorMoonPhaseInRange(start: startMoonPhaseFraction, end: endMoonPhaseFraction))
     XCTAssertEqual(fullMoon, .fullMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 1, day: 26)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    beginningAndEndJulianDays = TinyMoon.Moon.startAndEndOfJulianDay(julianDay: julianDay)
-    startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: beginningAndEndJulianDays.start).phase
-    endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: beginningAndEndJulianDays.end).phase
+    date = TinyMoon.formatDate(year: 2024, month: 1, day: 26, timeZone: utcTimeZone)
+    (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
+    startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: start).phase
+    endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: end).phase
     XCTAssertNil(TinyMoon.Moon.majorMoonPhaseInRange(start: startMoonPhaseFraction, end: endMoonPhaseFraction))
 
     // New Moon
-    date = TinyMoon.formatDate(year: 2024, month: 10, day: 02, hour: 00)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    beginningAndEndJulianDays = TinyMoon.Moon.startAndEndOfJulianDay(julianDay: julianDay)
-    startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: beginningAndEndJulianDays.start).phase
-    endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: beginningAndEndJulianDays.end).phase
+    date = TinyMoon.formatDate(year: 2024, month: 10, day: 02, hour: 00, timeZone: utcTimeZone)
+    (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
+    startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: start).phase
+    endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: end).phase
     let newMoon = try XCTUnwrap(TinyMoon.Moon.majorMoonPhaseInRange(start: startMoonPhaseFraction, end: endMoonPhaseFraction))
     XCTAssertEqual(newMoon, .newMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 10, day: 03, hour: 00)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    beginningAndEndJulianDays = TinyMoon.Moon.startAndEndOfJulianDay(julianDay: julianDay)
-    startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: beginningAndEndJulianDays.start).phase
-    endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: beginningAndEndJulianDays.end).phase
+    date = TinyMoon.formatDate(year: 2024, month: 10, day: 03, hour: 00, timeZone: utcTimeZone)
+    (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
+    startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: start).phase
+    endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: end).phase
     XCTAssertNil(TinyMoon.Moon.majorMoonPhaseInRange(start: startMoonPhaseFraction, end: endMoonPhaseFraction))
   }
 

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -4,68 +4,103 @@ import XCTest
 final class TinyMoonTests: XCTestCase {
 
   func test_moon_daysUntilFullMoon() {
+    let utcTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
+
     // Full Moon at Jun 22  01:07
     var date = TinyMoon.formatDate(year: 2024, month: 06, day: 20)
     var julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    var daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay)
+    var daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 2)
 
     // Full Moon at Sep 18  02:34
     date = TinyMoon.formatDate(year: 2024, month: 09, day: 12)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 6)
 
-    // Full Moon at Apr 23  23:48
+    // Full Moon at Jan 25  17:54
     date = TinyMoon.formatDate(year: 2024, month: 01, day: 20)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 5)
 
     // Full Moon at Nov 15  21:28
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 13)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 2)
 
     // Full Moon at Feb 24  12:30
     date = TinyMoon.formatDate(year: 2024, month: 01, day: 26)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 29)
   }
 
   func test_moon_daysUntilNewMoon() {
+    let utcTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
+
     // New Moon at May 8  03:21
     var date = TinyMoon.formatDate(year: 2024, month: 05, day: 06)
     var julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    var daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay)
+    var daysTill = TinyMoon.Moon.daysUntilNewMoon(
+      moonPhase: .waningGibbous,
+      julianDay: julianDay,
+      date: date,
+      timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 2)
+
+    date = TinyMoon.formatDate(year: 2024, month: 05, day: 07)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 1)
 
     // New Moon at Jul 5  22:57
     date = TinyMoon.formatDate(year: 2024, month: 07, day: 02)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 3)
+
+    date = TinyMoon.formatDate(year: 2024, month: 07, day: 03)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 2)
+
+    date = TinyMoon.formatDate(year: 2024, month: 07, day: 04)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 1)
 
     // New Moon at Dec 1  06:21
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 24)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 7)
 
     // New Moon at Nov 1  12:47
+    date = TinyMoon.formatDate(year: 2024, month: 10, day: 31)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 1)
+
+    date = TinyMoon.formatDate(year: 2024, month: 11, day: 1)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 0)
+
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 03)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 29)
   }
 
   func test_moon_uniquePhases() {
+    let utcTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
+
     var emojisByMonth = [MonthTestHelper.Month: Int]()
 
     for month in MonthTestHelper.Month.allCases {
-      let moons = MoonTestHelper.moonObjectsForMonth(month: month, year: 2024)
+      let moons = MoonTestHelper.moonObjectsForMonth(month: month, year: 2024, timeZone: utcTimeZone)
       let emojis = moons.compactMap { moon in
         switch moon.moonPhase {
         case .newMoon, .firstQuarter, .fullMoon, .lastQuarter:
@@ -180,18 +215,25 @@ final class TinyMoonTests: XCTestCase {
   func test_moon_dayIncludesMajorMoonPhase() throws {
     var date = TinyMoon.formatDate(year: 2024, month: 10, day: 17)
     var julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    var possibleMajorPhase = TinyMoon.Moon.dayIncludesMajorMoonPhase(julianDay: julianDay)
+    // HAVE to add TIMEZONE
+    var possibleMajorPhase = TinyMoon.Moon.dayIncludesMajorMoonPhase(
+      julianDay: julianDay,
+      date: date,
+      timeZone: TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc))
     let majorPhase = try XCTUnwrap(possibleMajorPhase)
     XCTAssertEqual(majorPhase, .fullMoon)
 
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 16)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    possibleMajorPhase = TinyMoon.Moon.dayIncludesMajorMoonPhase(julianDay: julianDay)
+    possibleMajorPhase = TinyMoon.Moon.dayIncludesMajorMoonPhase(julianDay: julianDay, date: date)
     XCTAssertNil(possibleMajorPhase)
 
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 18)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    possibleMajorPhase = TinyMoon.Moon.dayIncludesMajorMoonPhase(julianDay: julianDay)
+    possibleMajorPhase = TinyMoon.Moon.dayIncludesMajorMoonPhase(
+      julianDay: julianDay,
+      date: date,
+      timeZone: TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc))
     XCTAssertNil(possibleMajorPhase)
   }
 
@@ -213,5 +255,88 @@ final class TinyMoonTests: XCTestCase {
     phaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay).phase
     moonPhase = TinyMoon.Moon.moonPhase(julianDay: julianDay, phaseFraction: phaseFraction)
     XCTAssertEqual(moonPhase, .waningGibbous)
+  }
+
+  func test_moon_timezone_support() {
+    let utcTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
+    let pacificTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .pacific)
+    let tokyoTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .tokyo)
+
+    // First Quarter Moon on
+    //  - Pacific:  Jun 13  10:18 pm
+    //  - UTC:      Jun 14  05:18
+    var date = TinyMoon.formatDate(year: 2024, month: 06, day: 13, timeZone: pacificTimeZone)
+    var moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
+    XCTAssertEqual(moon.moonPhase, .firstQuarter)
+
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 14, timeZone: utcTimeZone)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
+    XCTAssertEqual(moon.moonPhase, .firstQuarter)
+
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 13, timeZone: utcTimeZone)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
+    XCTAssertNotEqual(moon.moonPhase, .firstQuarter)
+
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 14, timeZone: pacificTimeZone)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
+    XCTAssertNotEqual(moon.moonPhase, .firstQuarter)
+
+    // Full Moon on
+    //  - Pacific:  Jun 21  18:07 pm
+    //  - UTC:      Jun 22  01:07
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 21, timeZone: pacificTimeZone)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 22, timeZone: utcTimeZone)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 22, timeZone: pacificTimeZone)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
+    XCTAssertNotEqual(moon.moonPhase, .fullMoon)
+
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 21, timeZone: utcTimeZone)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
+    XCTAssertNotEqual(moon.moonPhase, .fullMoon)
+
+
+    // Full Moon on
+    //  - UTC:    Aug 19  18:25
+    //  - Tokyo:  Aug 20  03:25
+    date = TinyMoon.formatDate(year: 2024, month: 08, day: 19, timeZone: utcTimeZone)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+
+    date = TinyMoon.formatDate(year: 2024, month: 08, day: 20, timeZone: tokyoTimeZone)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: tokyoTimeZone)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+
+    date = TinyMoon.formatDate(year: 2024, month: 08, day: 19, timeZone: tokyoTimeZone)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: tokyoTimeZone)
+    XCTAssertNotEqual(moon.moonPhase, .fullMoon)
+
+    date = TinyMoon.formatDate(year: 2024, month: 08, day: 20, timeZone: utcTimeZone)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
+    XCTAssertNotEqual(moon.moonPhase, .fullMoon)
+
+    // Full Moon on
+    //  - UTC:  Nov 15 21:28
+    //  - Tokyo Nov 16 06:28
+    date = TinyMoon.formatDate(year: 2024, month: 11, day: 15, timeZone: utcTimeZone)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+
+    date = TinyMoon.formatDate(year: 2024, month: 11, day: 16, timeZone: tokyoTimeZone)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: tokyoTimeZone)
+    XCTAssertEqual(moon.moonPhase, .fullMoon)
+
+    date = TinyMoon.formatDate(year: 2024, month: 11, day: 16, timeZone: utcTimeZone)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
+    XCTAssertNotEqual(moon.moonPhase, .fullMoon)
+
+    date = TinyMoon.formatDate(year: 2024, month: 11, day: 15, timeZone: tokyoTimeZone)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: tokyoTimeZone)
+    XCTAssertNotEqual(moon.moonPhase, .fullMoon)
   }
 }

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -12,11 +12,26 @@ final class TinyMoonTests: XCTestCase {
     var daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 2)
 
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 21)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 1)
+
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 22)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 0)
+
     // Full Moon at Sep 18  02:34
     date = TinyMoon.formatDate(year: 2024, month: 09, day: 12)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 6)
+
+    date = TinyMoon.formatDate(year: 2024, month: 09, day: 17)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 1)
 
     // Full Moon at Jan 25  17:54
     date = TinyMoon.formatDate(year: 2024, month: 01, day: 20)
@@ -24,17 +39,52 @@ final class TinyMoonTests: XCTestCase {
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 5)
 
+    date = TinyMoon.formatDate(year: 2024, month: 01, day: 24)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 1)
+
+    date = TinyMoon.formatDate(year: 2024, month: 01, day: 25)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 0)
+
     // Full Moon at Nov 15  21:28
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 13)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 2)
 
+    date = TinyMoon.formatDate(year: 2024, month: 11, day: 14)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 1)
+
+    date = TinyMoon.formatDate(year: 2024, month: 11, day: 15)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 0)
+
     // Full Moon at Feb 24  12:30
+    date = TinyMoon.formatDate(year: 2024, month: 01, day: 25)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 0)
+
     date = TinyMoon.formatDate(year: 2024, month: 01, day: 26)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 29)
+
+    date = TinyMoon.formatDate(year: 2024, month: 02, day: 23)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 1)
+
+    date = TinyMoon.formatDate(year: 2024, month: 02, day: 24)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 0)
   }
 
   func test_moon_daysUntilNewMoon() {
@@ -55,7 +105,28 @@ final class TinyMoonTests: XCTestCase {
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
-    // New Moon at Jul 5  22:57
+    // New Moon at Jun 6  12:37 UTC
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 03)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 3)
+
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 04)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 2)
+
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 05)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 1)
+
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 06)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 0)
+
+    // New Moon at Jul 5  22:57 UTC
     date = TinyMoon.formatDate(year: 2024, month: 07, day: 02)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
@@ -70,6 +141,11 @@ final class TinyMoonTests: XCTestCase {
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
+    
+    date = TinyMoon.formatDate(year: 2024, month: 07, day: 05)
+    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    XCTAssertEqual(daysTill, 0)
 
     // New Moon at Dec 1  06:21
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 24)
@@ -280,6 +356,19 @@ final class TinyMoonTests: XCTestCase {
     date = TinyMoon.formatDate(year: 2024, month: 06, day: 14, timeZone: pacificTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertNotEqual(moon.moonPhase, .firstQuarter)
+
+    // New Moon on
+    //  - Pacific:  Jun 6  05:37
+    //  - UTC:      Jun 6  12:37
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 06, timeZone: pacificTimeZone)
+    print(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
+    XCTAssertEqual(moon.moonPhase, .newMoon)
+
+    date = TinyMoon.formatDate(year: 2024, month: 06, day: 06, timeZone: utcTimeZone)
+    print(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
+    XCTAssertEqual(moon.moonPhase, .newMoon)
 
     // Full Moon on
     //  - Pacific:  Jun 21  18:07 pm

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -8,82 +8,67 @@ final class TinyMoonTests: XCTestCase {
 
     // Full Moon at Jun 22  01:07
     var date = TinyMoon.formatDate(year: 2024, month: 06, day: 20)
-    var julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    var daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    var daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 2)
 
     date = TinyMoon.formatDate(year: 2024, month: 06, day: 21)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
     date = TinyMoon.formatDate(year: 2024, month: 06, day: 22)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
 
     // Full Moon at Sep 18  02:34
     date = TinyMoon.formatDate(year: 2024, month: 09, day: 12)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 6)
 
     date = TinyMoon.formatDate(year: 2024, month: 09, day: 17)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
     // Full Moon at Jan 25  17:54
     date = TinyMoon.formatDate(year: 2024, month: 01, day: 20)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 5)
 
     date = TinyMoon.formatDate(year: 2024, month: 01, day: 24)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
     date = TinyMoon.formatDate(year: 2024, month: 01, day: 25)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
 
     // Full Moon at Nov 15  21:28
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 13)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 2)
 
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 14)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 15)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
 
     // Full Moon at Feb 24  12:30
     date = TinyMoon.formatDate(year: 2024, month: 01, day: 25)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
 
     date = TinyMoon.formatDate(year: 2024, month: 01, day: 26)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 29)
 
     date = TinyMoon.formatDate(year: 2024, month: 02, day: 23)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
     date = TinyMoon.formatDate(year: 2024, month: 02, day: 24)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
   }
 
@@ -92,81 +77,66 @@ final class TinyMoonTests: XCTestCase {
 
     // New Moon at May 8  03:21
     var date = TinyMoon.formatDate(year: 2024, month: 05, day: 06)
-    var julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     var daysTill = TinyMoon.Moon.daysUntilNewMoon(
       moonPhase: .waningGibbous,
-      julianDay: julianDay,
       date: date,
       timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 2)
 
     date = TinyMoon.formatDate(year: 2024, month: 05, day: 07)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
     // New Moon at Jun 6  12:37 UTC
     date = TinyMoon.formatDate(year: 2024, month: 06, day: 03)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 3)
 
     date = TinyMoon.formatDate(year: 2024, month: 06, day: 04)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 2)
 
     date = TinyMoon.formatDate(year: 2024, month: 06, day: 05)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
     date = TinyMoon.formatDate(year: 2024, month: 06, day: 06)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
 
     // New Moon at Jul 5  22:57 UTC
     date = TinyMoon.formatDate(year: 2024, month: 07, day: 02)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 3)
 
     date = TinyMoon.formatDate(year: 2024, month: 07, day: 03)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 2)
 
     date = TinyMoon.formatDate(year: 2024, month: 07, day: 04)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
     date = TinyMoon.formatDate(year: 2024, month: 07, day: 05)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
 
     // New Moon at Dec 1  06:21
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 24)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 7)
 
     // New Moon at Nov 1  12:47
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 31)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 1)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous,date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
 
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 03)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
+    daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 29)
   }
 
@@ -289,47 +259,45 @@ final class TinyMoonTests: XCTestCase {
   }
 
   func test_moon_dayIncludesMajorMoonPhase() throws {
+    let utcTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
+
     var date = TinyMoon.formatDate(year: 2024, month: 10, day: 17)
-    var julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    // HAVE to add TIMEZONE
     var possibleMajorPhase = TinyMoon.Moon.dayIncludesMajorMoonPhase(
-      julianDay: julianDay,
       date: date,
-      timeZone: TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc))
+      timeZone: utcTimeZone)
     let majorPhase = try XCTUnwrap(possibleMajorPhase)
     XCTAssertEqual(majorPhase, .fullMoon)
 
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 16)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
-    possibleMajorPhase = TinyMoon.Moon.dayIncludesMajorMoonPhase(julianDay: julianDay, date: date)
+    possibleMajorPhase = TinyMoon.Moon.dayIncludesMajorMoonPhase(date: date, timeZone: utcTimeZone)
     XCTAssertNil(possibleMajorPhase)
 
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 18)
-    julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     possibleMajorPhase = TinyMoon.Moon.dayIncludesMajorMoonPhase(
-      julianDay: julianDay,
       date: date,
-      timeZone: TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc))
+      timeZone: utcTimeZone)
     XCTAssertNil(possibleMajorPhase)
   }
 
   func test_moon_moonPhase() {
+    let utcTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
+
     var date = TinyMoon.formatDate(year: 2024, month: 10, day: 16)
     var julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     var phaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay).phase
-    var moonPhase = TinyMoon.Moon.moonPhase(julianDay: julianDay, phaseFraction: phaseFraction)
+    var moonPhase = TinyMoon.Moon.moonPhase(phaseFraction: phaseFraction, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(moonPhase, .waxingGibbous)
 
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 17)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     phaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay).phase
-    moonPhase = TinyMoon.Moon.moonPhase(julianDay: julianDay, phaseFraction: phaseFraction)
+    moonPhase = TinyMoon.Moon.moonPhase(phaseFraction: phaseFraction, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(moonPhase, .fullMoon)
 
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 18)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     phaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay).phase
-    moonPhase = TinyMoon.Moon.moonPhase(julianDay: julianDay, phaseFraction: phaseFraction)
+    moonPhase = TinyMoon.Moon.moonPhase(phaseFraction: phaseFraction, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(moonPhase, .waningGibbous)
   }
 

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -141,7 +141,7 @@ final class TinyMoonTests: XCTestCase {
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
-    
+
     date = TinyMoon.formatDate(year: 2024, month: 07, day: 05)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, julianDay: julianDay, date: date, timeZone: utcTimeZone)

--- a/Tests/TinyMoonTests/UTCTests.swift
+++ b/Tests/TinyMoonTests/UTCTests.swift
@@ -18,12 +18,14 @@ final class UTCTests: XCTestCase {
     var correct = 0.0
     var incorrect = 0.0
 
+    let timeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
+
     let newMoonEmoji = TinyMoon.MoonPhase.newMoon.emoji
     let waningCrescentEmoji = TinyMoon.MoonPhase.waningCrescent.emoji
 
     // Returns a New Moon because it falls within this day's 24 hours
     var date = TinyMoon.formatDate(year: 2024, month: 09, day: 02, hour: 00, minute: 00)
-    let moon = TinyMoon.calculateMoonPhase(date)
+    let moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
@@ -44,94 +46,96 @@ final class UTCTests: XCTestCase {
     var correct = 0.0
     var incorrect = 0.0
 
+    let timeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
+
     let newMoonEmoji = TinyMoon.MoonPhase.newMoon.emoji
 
     var date = TinyMoon.formatDate(year: 2024, month: 01, day: 11)
-    var moon = TinyMoon.calculateMoonPhase(date)
+    var moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 02, day: 09)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 03, day: 10)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 04, day: 08)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 05, day: 08)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 06, day: 06)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 07, day: 05)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 08, day: 04)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
 //    date = TinyMoon.formatDate(year: 2024, month: 09, day: 03)
-//    moon = TinyMoon.calculateMoonPhase(date)
+//    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
 //    XCTAssertEqual(moon.moonPhase, .newMoon)
 //    XCTAssertEqual(moon.emoji, newMoonEmoji)
 //    XCTAssertEqual(moon.daysTillNewMoon, 0)
 //    if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 02)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 01)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 12, day: 01)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 12, day: 30)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
@@ -146,76 +150,78 @@ final class UTCTests: XCTestCase {
     var correct = 0.0
     var incorrect = 0.0
 
+    let timeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
+
     let firstQuarterEmoji = TinyMoon.MoonPhase.firstQuarter.emoji
 
     var date = TinyMoon.formatDate(year: 2024, month: 01, day: 18)
-    var moon = TinyMoon.calculateMoonPhase(date)
+    var moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 02, day: 16)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 03, day: 17)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 04, day: 15)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 05, day: 15)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 06, day: 14)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 07, day: 13)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 08, day: 12)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 09, day: 11)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 10)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 09)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 12, day: 08)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
@@ -229,6 +235,8 @@ final class UTCTests: XCTestCase {
     var correct = 0.0
     var incorrect = 0.0
 
+    let timeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
+
     let fullMoonEmoji = TinyMoon.MoonPhase.fullMoon.emoji
     let waxingGibbousEmoji = TinyMoon.MoonPhase.waxingGibbous.emoji
 
@@ -241,7 +249,7 @@ final class UTCTests: XCTestCase {
 
     // Although it is the same date and time, since a major phase (Full Moon) occurs within this day's 24 hours, this returns Full Moon
     date = TinyMoon.formatDate(year: 2024, month: 08, day: 19, hour: 00, minute: 00)
-    let moon = TinyMoon.calculateMoonPhase(date)
+    let moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
@@ -255,87 +263,89 @@ final class UTCTests: XCTestCase {
     var correct = 0.0
     var incorrect = 0.0
 
+    let timeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
+
     let fullMoonEmoji = TinyMoon.MoonPhase.fullMoon.emoji
 
     var date = TinyMoon.formatDate(year: 2024, month: 01, day: 25)
-    var moon = TinyMoon.calculateMoonPhase(date)
+    var moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 02, day: 24)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 03, day: 25)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
 //    date = TinyMoon.formatDate(year: 2024, month: 04, day: 23)
-//    moon = TinyMoon.calculateMoonPhase(date)
+//    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
 //    XCTAssertEqual(moon.moonPhase, .fullMoon)
 //    XCTAssertEqual(moon.emoji, fullMoonEmoji)
 //    XCTAssertEqual(moon.daysTillFullMoon, 0)
 //    if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 05, day: 23)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 06, day: 22)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 07, day: 21)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 08, day: 19)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 09, day: 18)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 17)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 15)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 12, day: 15)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
@@ -350,82 +360,84 @@ final class UTCTests: XCTestCase {
     var correct = 0.0
     var incorrect = 0.0
 
+    let timeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
+
     let lastQuarterEmoji = TinyMoon.MoonPhase.lastQuarter.emoji
 
     var date = TinyMoon.formatDate(year: 2024, month: 01, day: 04)
-    var moon = TinyMoon.calculateMoonPhase(date)
+    var moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 02, day: 02)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 03, day: 03)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
 //    date = TinyMoon.formatDate(year: 2024, month: 04, day: 02)
-//    moon = TinyMoon.calculateMoonPhase(date)
+//    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
 //    XCTAssertEqual(moon.moonPhase, .lastQuarter)
 //    XCTAssertEqual(moon.emoji, lastQuarterEmoji)
 //    if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 05, day: 01)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 05, day: 30)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 06, day: 28)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 07, day: 28)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 08, day: 26)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 09, day: 24)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 10, day: 24)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 11, day: 23)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TinyMoon.formatDate(year: 2024, month: 12, day: 22)
-    moon = TinyMoon.calculateMoonPhase(date)
+    moon = TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }


### PR DESCRIPTION
Closes #21 and closes #28

Adds timezone support to TinyMoon and fixes a major flaw within the library. 

Timezones are needed to calculate an exact time. Before, everything was calculated off of the current user's system timezone, leading to incorrect results. 

I added extensive timezone tests: https://github.com/mannylopez/TinyMoon/pull/26/commits/f4773e51384c47cb07758992ecc516e4da0b5b80#diff-86442e8ab0a16ee48438bbc6f15bed110625d172a752c18b258604cf840ff9d8

Now that I am using a Date with timezones, I can remove a lot of the Julian Day usage. I've updated function signatures, doccumentation, and tests to reflect this.

Other updates:
**Fixed a bug where minorMoonPhase was returning a major moon phase**
```diff
    static func minorMoonPhase(phaseFraction: Double) -> MoonPhase {
--      if phaseFraction < 0.23 {
--        .waxingCrescent
--      } else if phaseFraction < 0.48 {
--        .waxingGibbous
--      } else if phaseFraction < 0.73 {
--        .waningGibbous
--      } else if phaseFraction < 0.98 {
--        .waningCrescent
++      if phaseFraction < 0.25 {
++        return .waxingCrescent
++      } else if phaseFraction < 0.50 {
++        return .waxingGibbous
++      } else if phaseFraction < 0.75 {
++        return .waningGibbous
      } else {
--        .newMoon
++        return .waningCrescent
      }
    }
```

**Refactor `julianStartAndEndOfDay` to take in a Date instead of a Julian Day**
```diff
-- static func startAndEndOfJulianDay(julianDay: Double) -> (start: Double, end: Double) {
--       let base = floor(julianDay) + (julianDay.truncatingRemainder(dividingBy: 1) < 0.5 ? -1 : 0)
--       let arr = [0.5, 1.4993].map { base + $0 }
--       return (start: arr[0], end: arr[1])
++ static func julianStartAndEndOfDay(date: Date, timeZone: TimeZone = TimeZone.current) -> (start: Double, end: Double) {
++      var calendar = Calendar.current
++      calendar.timeZone = timeZone
++      let startOfDay = calendar.startOfDay(for: date)
++      let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay)
++      let startJulianDay = AstronomicalConstant.julianDay(startOfDay)
++      let endJulianDay = AstronomicalConstant.julianDay(endOfDay!)
++      return (start: startJulianDay, end: endJulianDay)
    }

```