### PR TITLE
Add MoonDetail to public API

### DIFF
--- a/Sources/TinyMoon/TinyMoon+Moon.swift
+++ b/Sources/TinyMoon/TinyMoon+Moon.swift
@@ -22,9 +22,9 @@ extension TinyMoon {
     init(date: Date, timeZone: TimeZone = TimeZone.current) {
       self.date = date
       let julianDay = AstronomicalConstant.julianDay(date)
-      let moonPhaseData = AstronomicalConstant.getMoonPhase(julianDay: julianDay)
-      phaseFraction = moonPhaseData.phase
-      illuminatedFraction = moonPhaseData.illuminatedFraction
+      moonDetail = AstronomicalConstant.getMoonPhase(julianDay: julianDay)
+      phaseFraction = moonDetail.phase
+      illuminatedFraction = moonDetail.illuminatedFraction
 
       moonPhase = Moon.moonPhase(phaseFraction: phaseFraction, date: date, timeZone: timeZone)
 
@@ -52,6 +52,7 @@ extension TinyMoon {
     public var daysTillFullMoon: Int
     /// Returns `0` if the current `date` is a new moon
     public var daysTillNewMoon: Int
+    public var moonDetail: TinyMoon.MoonDetail
 
     public var fullMoonName: String? {
       if isFullMoon() {

--- a/Sources/TinyMoon/TinyMoon+MoonDetail.swift
+++ b/Sources/TinyMoon/TinyMoon+MoonDetail.swift
@@ -6,16 +6,17 @@ import Foundation
 
 extension TinyMoon {
 
-  struct MoonDetail {
-    let julianDay: Double
+  public struct MoonDetail: Hashable {
+
+    public let julianDay: Double
     /// Number of days elapsed into the synodic cycle, represented as a fraction
-    let daysElapsedInCycle: Double
+    public let daysElapsedInCycle: Double
     /// Age of the moon in days, minutes, hours
-    let ageOfMoon: (days: Int, hours: Int, minutes: Int)
+    public let ageOfMoon: (days: Int, hours: Int, minutes: Int)
     /// Illuminated portion of the Moon, where 0.0 = new and 0.99 = full
-    let illuminatedFraction: Double
+    public let illuminatedFraction: Double
     /// Distance of moon from the center of the Earth, in kilometers
-    let distanceFromCenterOfEarth: Double
+    public let distanceFromCenterOfEarth: Double
     /// Phase of the Moon, represented as a fraction
     ///
     /// Varies between `0.0` to `0.99`.
@@ -23,6 +24,29 @@ extension TinyMoon {
     /// `0.25` first quarter,
     /// `0.5` full moon,
     /// `0.75` last quarter
-    let phase: Double
+    public let phase: Double
+
+    public static func == (lhs: TinyMoon.MoonDetail, rhs: TinyMoon.MoonDetail) -> Bool {
+      lhs.julianDay == rhs.julianDay &&
+        lhs.daysElapsedInCycle == rhs.daysElapsedInCycle &&
+        lhs.ageOfMoon.days == rhs.ageOfMoon.days &&
+        lhs.ageOfMoon.hours == rhs.ageOfMoon.hours &&
+        lhs.ageOfMoon.minutes == rhs.ageOfMoon.minutes &&
+        lhs.illuminatedFraction == rhs.illuminatedFraction &&
+        lhs.distanceFromCenterOfEarth == rhs.distanceFromCenterOfEarth &&
+        lhs.phase == rhs.phase
+    }
+
+    public func hash(into hasher: inout Hasher) {
+      hasher.combine(julianDay)
+      hasher.combine(daysElapsedInCycle)
+      hasher.combine(ageOfMoon.days)
+      hasher.combine(ageOfMoon.hours)
+      hasher.combine(ageOfMoon.minutes)
+      hasher.combine(illuminatedFraction)
+      hasher.combine(distanceFromCenterOfEarth)
+      hasher.combine(phase)
+    }
+
   }
 }


### PR DESCRIPTION
Exposing MoonDetail to the public TinyMoon API. 

Eventually the properties in MoonDetail will be added to the public API directly.