### PR TITLE
Move time date and timezone helpers to TimeTestHelper

### DIFF
--- a/Sources/TinyMoon/TinyMoon.swift
+++ b/Sources/TinyMoon/TinyMoon.swift
@@ -2,8 +2,6 @@ import Foundation
 
 public enum TinyMoon {
 
-  // MARK: Public
-
   /// The `Moon` object for a specific date, prioritizing major phases (new moon, first quarter, full moon, last quarter) .
   ///
   /// Use this object when you need a general understanding of the moon's phase for a day, especially when emphasizing the major phases is important for your application's context.
@@ -29,48 +27,6 @@ public enum TinyMoon {
   public static func calculateExactMoonPhase(_ date: Date = Date()) -> ExactMoon {
     let moon = Moon(date: date)
     return ExactMoon(date: date, phaseFraction: moon.phaseFraction)
-  }
-
-  // MARK: Internal
-
-  enum TimeZoneOption {
-    case utc
-    case pacific
-    case tokyo
-
-    static func createTimeZone(timeZone: TimeZoneOption) -> TimeZone {
-      switch timeZone {
-      case .utc:
-        TimeZone(identifier: "UTC")!
-      case .pacific:
-        TimeZone(identifier: "America/Los_Angeles")!
-      case .tokyo:
-        TimeZone(identifier: "Asia/Tokyo")!
-      }
-    }
-  }
-
-  /// Creates a Date from the given arguments. Default is in UTC timezone.
-  static func formatDate(
-    year: Int,
-    month: Int,
-    day: Int,
-    hour: Int = 00,
-    minute: Int = 00,
-    second: Int = 00,
-    timeZone: TimeZone = TimeZoneOption.createTimeZone(timeZone: .utc))
-    -> Date
-  {
-    var components = DateComponents()
-    components.year = year
-    components.month = month
-    components.day = day
-    components.hour = hour
-    components.minute = minute
-    components.second = second
-    components.timeZone = timeZone
-
-    return Calendar.current.date(from: components)!
   }
 
 }

--- a/Tests/TinyMoonTests/AstronomicalConstantTests.swift
+++ b/Tests/TinyMoonTests/AstronomicalConstantTests.swift
@@ -22,16 +22,16 @@ final class AstronomicalConstantTests: XCTestCase {
   }
 
   func test_astronomicalConstant_julianDay() {
-    let pacificTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .pacific)
+    let pacificTimeZone = TimeTestHelper.TimeZoneOption.createTimeZone(timeZone: .pacific)
 
     // January 6, 2000 @ 00:00:00
-    var date = TinyMoon.formatDate(year: 2000, month: 01, day: 06)
+    var date = TimeTestHelper.formatDate(year: 2000, month: 01, day: 06)
     var julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     XCTAssertEqual(julianDay, 2451549.5000)
 
     // January 6, 2000 @ 00:00: Pacific
     // January 6, 2000 @ 08:00:00 UTC
-    date = TinyMoon.formatDate(
+    date = TimeTestHelper.formatDate(
       year: 2000,
       month: 01,
       day: 06,
@@ -42,7 +42,7 @@ final class AstronomicalConstantTests: XCTestCase {
 
     // January 5, 2000 @ 16:00: Pacific
     // January 6, 2000 @ 00:00:00 UTC
-    date = TinyMoon.formatDate(
+    date = TimeTestHelper.formatDate(
       year: 2000,
       month: 01,
       day: 5,
@@ -52,33 +52,33 @@ final class AstronomicalConstantTests: XCTestCase {
     XCTAssertEqual(julianDay, 2451549.5000)
 
     // January 6, 2000 @ 20:00:00
-    date = TinyMoon.formatDate(year: 2000, month: 01, day: 06, hour: 20, minute: 00)
+    date = TimeTestHelper.formatDate(year: 2000, month: 01, day: 06, hour: 20, minute: 00)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     XCTAssertEqual(julianDay, 2451550.3333333335)
 
     // August 22, 2022 @ 00:00:00
-    date = TinyMoon.formatDate(year: 2022, month: 08, day: 22, hour: 00, minute: 00)
+    date = TimeTestHelper.formatDate(year: 2022, month: 08, day: 22, hour: 00, minute: 00)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     XCTAssertEqual(julianDay, 2459813.5000)
 
     // August 22, 2022 @ 04:05:00
-    date = TinyMoon.formatDate(year: 2022, month: 08, day: 22, hour: 04, minute: 05)
+    date = TimeTestHelper.formatDate(year: 2022, month: 08, day: 22, hour: 04, minute: 05)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     XCTAssertEqual(julianDay, 2459813.670138889)
 
     // August 22, 2022 @ 14:05:00
-    date = TinyMoon.formatDate(year: 2022, month: 08, day: 22, hour: 14, minute: 05)
+    date = TimeTestHelper.formatDate(year: 2022, month: 08, day: 22, hour: 14, minute: 05)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     XCTAssertEqual(julianDay, 2459814.0868055555)
 
-    date = TinyMoon.formatDate(year: 2022, month: 08, day: 22, hour: 23, minute: 59)
+    date = TimeTestHelper.formatDate(year: 2022, month: 08, day: 22, hour: 23, minute: 59)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     XCTAssertEqual(julianDay, 2459814.4993055556)
   }
 
   func test_astronomicalConstant_getMoonPhase_moonDetail() {
     // Full moon
-    var date = TinyMoon.formatDate(year: 2024, month: 06, day: 22)
+    var date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 22)
     var julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     var moonDetail = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay)
 
@@ -92,7 +92,7 @@ final class AstronomicalConstantTests: XCTestCase {
     XCTAssertEqual(moonDetail.phase, 0.49835304181785745)
 
     // New moon
-    date = TinyMoon.formatDate(year: 2024, month: 07, day: 06, hour: 12, minute: 37)
+    date = TimeTestHelper.formatDate(year: 2024, month: 07, day: 06, hour: 12, minute: 37)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     moonDetail = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay)
 
@@ -106,7 +106,7 @@ final class AstronomicalConstantTests: XCTestCase {
     XCTAssertEqual(moonDetail.phase, 0.019184351732275336)
 
     // First quarter
-    date = TinyMoon.formatDate(year: 2024, month: 08, day: 12, hour: 15, minute: 18)
+    date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 12, hour: 15, minute: 18)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     moonDetail = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay)
 
@@ -120,7 +120,7 @@ final class AstronomicalConstantTests: XCTestCase {
     XCTAssertEqual(moonDetail.phase, 0.2505449551679033)
 
     // Last quarter
-    date = TinyMoon.formatDate(year: 2024, month: 08, day: 26, hour: 09, minute: 25)
+    date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 26, hour: 09, minute: 25)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     moonDetail = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay)
 
@@ -136,8 +136,8 @@ final class AstronomicalConstantTests: XCTestCase {
 
   func test_moontool() {
     // Test taken from https://www.fourmilab.ch/moontoolw/
-    let utcTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
-    let date = TinyMoon.formatDate(year: 1999, month: 07, day: 20, hour: 20, minute: 17, second: 40, timeZone: utcTimeZone)
+    let utcTimeZone = TimeTestHelper.TimeZoneOption.createTimeZone(timeZone: .utc)
+    let date = TimeTestHelper.formatDate(year: 1999, month: 07, day: 20, hour: 20, minute: 17, second: 40, timeZone: utcTimeZone)
     let julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     let moonDetail = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay)
     XCTAssertEqual(moonDetail.julianDay, 2451380.345601852)

--- a/Tests/TinyMoonTests/Helpers/MoonTestHelper.swift
+++ b/Tests/TinyMoonTests/Helpers/MoonTestHelper.swift
@@ -18,7 +18,7 @@ enum MoonTestHelper {
     timeZone: TimeZone = utcTimeZone)
     -> TinyMoon.Moon
   {
-    let date = TinyMoon.formatDate(year: year, month: month, day: day, hour: hour, minute: minute, timeZone: timeZone)
+    let date = TimeTestHelper.formatDate(year: year, month: month, day: day, hour: hour, minute: minute, timeZone: timeZone)
     return TinyMoon.calculateMoonPhase(date, timeZone: timeZone)
   }
 

--- a/Tests/TinyMoonTests/Helpers/TimeTestHelper.swift
+++ b/Tests/TinyMoonTests/Helpers/TimeTestHelper.swift
@@ -1,0 +1,46 @@
+// Created by manny_lopez on 7/22/24.
+
+import Foundation
+
+enum TimeTestHelper {
+
+  enum TimeZoneOption {
+    case utc
+    case pacific
+    case tokyo
+
+    static func createTimeZone(timeZone: TimeZoneOption) -> TimeZone {
+      switch timeZone {
+      case .utc:
+        TimeZone(identifier: "UTC")!
+      case .pacific:
+        TimeZone(identifier: "America/Los_Angeles")!
+      case .tokyo:
+        TimeZone(identifier: "Asia/Tokyo")!
+      }
+    }
+  }
+
+  /// Creates a Date from the given arguments. Default is in UTC timezone.
+  static func formatDate(
+    year: Int,
+    month: Int,
+    day: Int,
+    hour: Int = 00,
+    minute: Int = 00,
+    second: Int = 00,
+    timeZone: TimeZone = TimeZoneOption.createTimeZone(timeZone: .utc))
+    -> Date
+  {
+    var components = DateComponents()
+    components.year = year
+    components.month = month
+    components.day = day
+    components.hour = hour
+    components.minute = minute
+    components.second = second
+    components.timeZone = timeZone
+
+    return Calendar.current.date(from: components)!
+  }
+}

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -3,138 +3,138 @@ import XCTest
 
 final class TinyMoonTests: XCTestCase {
 
-  let utcTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
-  let pacificTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .pacific)
+  let utcTimeZone = TimeTestHelper.TimeZoneOption.createTimeZone(timeZone: .utc)
+  let pacificTimeZone = TimeTestHelper.TimeZoneOption.createTimeZone(timeZone: .pacific)
 
   func test_moon_daysUntilFullMoon() {
     // Full Moon at Jun 22  01:07
-    var date = TinyMoon.formatDate(year: 2024, month: 06, day: 20)
+    var date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 20)
     var daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 2)
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 21)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 21)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 22)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 22)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
 
     // Full Moon at Sep 18  02:34
-    date = TinyMoon.formatDate(year: 2024, month: 09, day: 12)
+    date = TimeTestHelper.formatDate(year: 2024, month: 09, day: 12)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 6)
 
-    date = TinyMoon.formatDate(year: 2024, month: 09, day: 17)
+    date = TimeTestHelper.formatDate(year: 2024, month: 09, day: 17)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
     // Full Moon at Jan 25  17:54
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 20)
+    date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 20)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 5)
 
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 24)
+    date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 24)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 25)
+    date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 25)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
 
     // Full Moon at Nov 15  21:28
-    date = TinyMoon.formatDate(year: 2024, month: 11, day: 13)
+    date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 13)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 2)
 
-    date = TinyMoon.formatDate(year: 2024, month: 11, day: 14)
+    date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 14)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
-    date = TinyMoon.formatDate(year: 2024, month: 11, day: 15)
+    date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 15)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
 
     // Full Moon at Feb 24  12:30
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 25)
+    date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 25)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
 
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 26)
+    date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 26)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 29)
 
-    date = TinyMoon.formatDate(year: 2024, month: 02, day: 23)
+    date = TimeTestHelper.formatDate(year: 2024, month: 02, day: 23)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
-    date = TinyMoon.formatDate(year: 2024, month: 02, day: 24)
+    date = TimeTestHelper.formatDate(year: 2024, month: 02, day: 24)
     daysTill = TinyMoon.Moon.daysUntilFullMoon(moonPhase: .newMoon, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
   }
 
   func test_moon_daysUntilNewMoon() {
     // New Moon at May 8  03:21
-    var date = TinyMoon.formatDate(year: 2024, month: 05, day: 06)
+    var date = TimeTestHelper.formatDate(year: 2024, month: 05, day: 06)
     var daysTill = TinyMoon.Moon.daysUntilNewMoon(
       moonPhase: .waningGibbous,
       date: date,
       timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 2)
 
-    date = TinyMoon.formatDate(year: 2024, month: 05, day: 07)
+    date = TimeTestHelper.formatDate(year: 2024, month: 05, day: 07)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
     // New Moon at Jun 6  12:37 UTC
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 03)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 03)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 3)
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 04)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 04)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 2)
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 05)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 05)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 06)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 06)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
 
     // New Moon at Jul 5  22:57 UTC
-    date = TinyMoon.formatDate(year: 2024, month: 07, day: 02)
+    date = TimeTestHelper.formatDate(year: 2024, month: 07, day: 02)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 3)
 
-    date = TinyMoon.formatDate(year: 2024, month: 07, day: 03)
+    date = TimeTestHelper.formatDate(year: 2024, month: 07, day: 03)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 2)
 
-    date = TinyMoon.formatDate(year: 2024, month: 07, day: 04)
+    date = TimeTestHelper.formatDate(year: 2024, month: 07, day: 04)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
-    date = TinyMoon.formatDate(year: 2024, month: 07, day: 05)
+    date = TimeTestHelper.formatDate(year: 2024, month: 07, day: 05)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
 
     // New Moon at Dec 1  06:21
-    date = TinyMoon.formatDate(year: 2024, month: 11, day: 24)
+    date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 24)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 7)
 
     // New Moon at Nov 1  12:47
-    date = TinyMoon.formatDate(year: 2024, month: 10, day: 31)
+    date = TimeTestHelper.formatDate(year: 2024, month: 10, day: 31)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 1)
 
-    date = TinyMoon.formatDate(year: 2024, month: 11, day: 1)
+    date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 1)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous,date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 0)
 
-    date = TinyMoon.formatDate(year: 2024, month: 10, day: 03)
+    date = TimeTestHelper.formatDate(year: 2024, month: 10, day: 03)
     daysTill = TinyMoon.Moon.daysUntilNewMoon(moonPhase: .waningGibbous, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(daysTill, 29)
   }
@@ -168,80 +168,80 @@ final class TinyMoonTests: XCTestCase {
   }
 
   func test_moon_startAndEndOfJulianDay() {
-    var date = TinyMoon.formatDate(year: 2024, month: 01, day: 11, hour: 00, timeZone: utcTimeZone)
+    var date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 11, hour: 00, timeZone: utcTimeZone)
     var (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
     XCTAssertEqual(start, 2460320.5)
     XCTAssertEqual(end, 2460321.5)
 
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 11, hour: 06, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 11, hour: 06, timeZone: utcTimeZone)
     (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
     XCTAssertEqual(start, 2460320.5)
     XCTAssertEqual(end, 2460321.5)
 
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 11, hour: 09, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 11, hour: 09, timeZone: utcTimeZone)
     (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
     XCTAssertEqual(start, 2460320.5)
     XCTAssertEqual(end, 2460321.5)
 
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 11, hour: 12, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 11, hour: 12, timeZone: utcTimeZone)
     (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
     XCTAssertEqual(start, 2460320.5)
     XCTAssertEqual(end, 2460321.5)
 
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 11, hour: 23, minute: 18, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 11, hour: 23, minute: 18, timeZone: utcTimeZone)
     (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
     XCTAssertEqual(start, 2460320.5)
     XCTAssertEqual(end, 2460321.5)
 
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 12, hour: 05, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 12, hour: 05, timeZone: utcTimeZone)
     (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
     XCTAssertEqual(start, 2460321.5)
     XCTAssertEqual(end, 2460322.5)
   }
 
   func test_moon_majorMoonPhaseInRange() throws {
-    var date = TinyMoon.formatDate(year: 2024, month: 04, day: 22, timeZone: utcTimeZone)
+    var date = TimeTestHelper.formatDate(year: 2024, month: 04, day: 22, timeZone: utcTimeZone)
     var (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
     var startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: start).phase
     var endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: end).phase
     XCTAssertNil(TinyMoon.Moon.majorMoonPhaseInRange(start: startMoonPhaseFraction, end: endMoonPhaseFraction))
 
-    date = TinyMoon.formatDate(year: 2024, month: 04, day: 23, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 04, day: 23, timeZone: utcTimeZone)
     (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
     startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: start).phase
     endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: end).phase
     var fullMoon = try XCTUnwrap(TinyMoon.Moon.majorMoonPhaseInRange(start: startMoonPhaseFraction, end: endMoonPhaseFraction))
     XCTAssertEqual(fullMoon, .fullMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 04, day: 24, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 04, day: 24, timeZone: utcTimeZone)
     (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
     startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: start).phase
     endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: end).phase
     XCTAssertNil(TinyMoon.Moon.majorMoonPhaseInRange(start: startMoonPhaseFraction, end: endMoonPhaseFraction))
 
     // Full Moon
-    date = TinyMoon.formatDate(year: 2024, month: 01, day: 25, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 25, timeZone: utcTimeZone)
     (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
     startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: start).phase
     endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: end).phase
     fullMoon = try XCTUnwrap(TinyMoon.Moon.majorMoonPhaseInRange(start: startMoonPhaseFraction, end: endMoonPhaseFraction))
     XCTAssertEqual(fullMoon, .fullMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 1, day: 26, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 1, day: 26, timeZone: utcTimeZone)
     (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
     startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: start).phase
     endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: end).phase
     XCTAssertNil(TinyMoon.Moon.majorMoonPhaseInRange(start: startMoonPhaseFraction, end: endMoonPhaseFraction))
 
     // New Moon
-    date = TinyMoon.formatDate(year: 2024, month: 10, day: 02, hour: 00, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 10, day: 02, hour: 00, timeZone: utcTimeZone)
     (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
     startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: start).phase
     endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: end).phase
     let newMoon = try XCTUnwrap(TinyMoon.Moon.majorMoonPhaseInRange(start: startMoonPhaseFraction, end: endMoonPhaseFraction))
     XCTAssertEqual(newMoon, .newMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 10, day: 03, hour: 00, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 10, day: 03, hour: 00, timeZone: utcTimeZone)
     (start, end) = TinyMoon.Moon.julianStartAndEndOfDay(date: date, timeZone: utcTimeZone)
     startMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: start).phase
     endMoonPhaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: end).phase
@@ -249,18 +249,18 @@ final class TinyMoonTests: XCTestCase {
   }
 
   func test_moon_dayIncludesMajorMoonPhase() throws {
-    var date = TinyMoon.formatDate(year: 2024, month: 10, day: 17)
+    var date = TimeTestHelper.formatDate(year: 2024, month: 10, day: 17)
     var possibleMajorPhase = TinyMoon.Moon.dayIncludesMajorMoonPhase(
       date: date,
       timeZone: utcTimeZone)
     let majorPhase = try XCTUnwrap(possibleMajorPhase)
     XCTAssertEqual(majorPhase, .fullMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 10, day: 16)
+    date = TimeTestHelper.formatDate(year: 2024, month: 10, day: 16)
     possibleMajorPhase = TinyMoon.Moon.dayIncludesMajorMoonPhase(date: date, timeZone: utcTimeZone)
     XCTAssertNil(possibleMajorPhase)
 
-    date = TinyMoon.formatDate(year: 2024, month: 10, day: 18)
+    date = TimeTestHelper.formatDate(year: 2024, month: 10, day: 18)
     possibleMajorPhase = TinyMoon.Moon.dayIncludesMajorMoonPhase(
       date: date,
       timeZone: utcTimeZone)
@@ -268,19 +268,19 @@ final class TinyMoonTests: XCTestCase {
   }
 
   func test_moon_moonPhase() {
-    var date = TinyMoon.formatDate(year: 2024, month: 10, day: 16)
+    var date = TimeTestHelper.formatDate(year: 2024, month: 10, day: 16)
     var julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     var phaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay).phase
     var moonPhase = TinyMoon.Moon.moonPhase(phaseFraction: phaseFraction, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(moonPhase, .waxingGibbous)
 
-    date = TinyMoon.formatDate(year: 2024, month: 10, day: 17)
+    date = TimeTestHelper.formatDate(year: 2024, month: 10, day: 17)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     phaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay).phase
     moonPhase = TinyMoon.Moon.moonPhase(phaseFraction: phaseFraction, date: date, timeZone: utcTimeZone)
     XCTAssertEqual(moonPhase, .fullMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 10, day: 18)
+    date = TimeTestHelper.formatDate(year: 2024, month: 10, day: 18)
     julianDay = TinyMoon.AstronomicalConstant.julianDay(date)
     phaseFraction = TinyMoon.AstronomicalConstant.getMoonPhase(julianDay: julianDay).phase
     moonPhase = TinyMoon.Moon.moonPhase(phaseFraction: phaseFraction, date: date, timeZone: utcTimeZone)
@@ -288,38 +288,38 @@ final class TinyMoonTests: XCTestCase {
   }
 
   func test_moon_timezone_support() {
-    let utcTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
-    let pacificTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .pacific)
-    let tokyoTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .tokyo)
+    let utcTimeZone = TimeTestHelper.TimeZoneOption.createTimeZone(timeZone: .utc)
+    let pacificTimeZone = TimeTestHelper.TimeZoneOption.createTimeZone(timeZone: .pacific)
+    let tokyoTimeZone = TimeTestHelper.TimeZoneOption.createTimeZone(timeZone: .tokyo)
 
     // First Quarter Moon on
     //  - Pacific:  Jun 13  10:18 pm
     //  - UTC:      Jun 14  05:18
-    var date = TinyMoon.formatDate(year: 2024, month: 06, day: 13, timeZone: pacificTimeZone)
+    var date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 13, timeZone: pacificTimeZone)
     var moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 14, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 14, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 13, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 13, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertNotEqual(moon.moonPhase, .firstQuarter)
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 14, timeZone: pacificTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 14, timeZone: pacificTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertNotEqual(moon.moonPhase, .firstQuarter)
 
     // New Moon on
     //  - Pacific:  Jun 6  05:37
     //  - UTC:      Jun 6  12:37
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 06, timeZone: pacificTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 06, timeZone: pacificTimeZone)
     print(date)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 06, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 06, timeZone: utcTimeZone)
     print(date)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
@@ -327,19 +327,19 @@ final class TinyMoonTests: XCTestCase {
     // Full Moon on
     //  - Pacific:  Jun 21  18:07 pm
     //  - UTC:      Jun 22  01:07
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 21, timeZone: pacificTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 21, timeZone: pacificTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 22, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 22, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 22, timeZone: pacificTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 22, timeZone: pacificTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertNotEqual(moon.moonPhase, .fullMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 21, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 21, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertNotEqual(moon.moonPhase, .fullMoon)
 
@@ -347,38 +347,38 @@ final class TinyMoonTests: XCTestCase {
     // Full Moon on
     //  - UTC:    Aug 19  18:25
     //  - Tokyo:  Aug 20  03:25
-    date = TinyMoon.formatDate(year: 2024, month: 08, day: 19, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 19, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 08, day: 20, timeZone: tokyoTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 20, timeZone: tokyoTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: tokyoTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 08, day: 19, timeZone: tokyoTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 19, timeZone: tokyoTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: tokyoTimeZone)
     XCTAssertNotEqual(moon.moonPhase, .fullMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 08, day: 20, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 20, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertNotEqual(moon.moonPhase, .fullMoon)
 
     // Full Moon on
     //  - UTC:  Nov 15 21:28
     //  - Tokyo Nov 16 06:28
-    date = TinyMoon.formatDate(year: 2024, month: 11, day: 15, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 15, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 11, day: 16, timeZone: tokyoTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 16, timeZone: tokyoTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: tokyoTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 11, day: 16, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 16, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertNotEqual(moon.moonPhase, .fullMoon)
 
-    date = TinyMoon.formatDate(year: 2024, month: 11, day: 15, timeZone: tokyoTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 15, timeZone: tokyoTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: tokyoTimeZone)
     XCTAssertNotEqual(moon.moonPhase, .fullMoon)
   }
@@ -395,37 +395,37 @@ final class TinyMoonTests: XCTestCase {
     // Values from https://www.timeanddate.com/moon/phases/usa/portland-or
 
     // Full moon on 2/24/2024 @ 04:30 PST
-    var date = TinyMoon.formatDate(year: 2024, month: 2, day: 24, hour: 4, minute: 30, timeZone: pacificTimeZone)
+    var date = TimeTestHelper.formatDate(year: 2024, month: 2, day: 24, hour: 4, minute: 30, timeZone: pacificTimeZone)
     var moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
 
     // New moon on 3/10/2024 @ 01:00 PST
-    date = TinyMoon.formatDate(year: 2024, month: 3, day: 10, hour: 1, minute: 0, timeZone: pacificTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 3, day: 10, hour: 1, minute: 0, timeZone: pacificTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
 
     // Full moon on 3/25/2024 @ 00:00 PST
-    date = TinyMoon.formatDate(year: 2024, month: 3, day: 25, hour: 0, minute: 0, timeZone: pacificTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 3, day: 25, hour: 0, minute: 0, timeZone: pacificTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
 
     // New moon on 3/10/2024 @ 01:00 PST
-    date = TinyMoon.formatDate(year: 2024, month: 3, day: 10, hour: 1, minute: 0, timeZone: pacificTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 3, day: 10, hour: 1, minute: 0, timeZone: pacificTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
 
     // New moon on 8/4/2024 @ 04:13 PST
-    date = TinyMoon.formatDate(year: 2024, month: 8, day: 4, hour: 4, minute: 13, timeZone: pacificTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 8, day: 4, hour: 4, minute: 13, timeZone: pacificTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
 
     // New moon on 11/30/2024 @ 22:21 PST
-    date = TinyMoon.formatDate(year: 2024, month: 11, day: 30, hour: 22, minute: 21, timeZone: pacificTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 30, hour: 22, minute: 21, timeZone: pacificTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
 
     // Full moon on 12/15/2024 @ 01:01 PST
-    date = TinyMoon.formatDate(year: 2024, month: 12, day: 15, hour: 1, minute: 01, timeZone: pacificTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 12, day: 15, hour: 1, minute: 01, timeZone: pacificTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
 
@@ -433,17 +433,17 @@ final class TinyMoonTests: XCTestCase {
     // Values from https://www.timeanddate.com/moon/phases/timezone/utc
 
     // Last Quarter moon on 4/2/2024 @ 03:14 UTC
-    date = TinyMoon.formatDate(year: 2024, month: 4, day: 2, hour: 3, minute: 14, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 4, day: 2, hour: 3, minute: 14, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
 
     // Full moon on 4/23/2024 @ 23:48 UTC
-    date = TinyMoon.formatDate(year: 2024, month: 4, day: 23, hour: 23, minute: 48, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 4, day: 23, hour: 23, minute: 48, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
 
     // New moon on 9/3/2024 @ 01:55 UTC
-    date = TinyMoon.formatDate(year: 2024, month: 9, day: 3, hour: 1, minute: 55, timeZone: utcTimeZone)
+    date = TimeTestHelper.formatDate(year: 2024, month: 9, day: 3, hour: 1, minute: 55, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
   }

--- a/Tests/TinyMoonTests/UTCTests.swift
+++ b/Tests/TinyMoonTests/UTCTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class UTCTests: XCTestCase {
 
-  let utcTimeZone = TinyMoon.TimeZoneOption.createTimeZone(timeZone: .utc)
+  let utcTimeZone = TimeTestHelper.TimeZoneOption.createTimeZone(timeZone: .utc)
 
   // MARK: Internal
 
@@ -24,7 +24,7 @@ final class UTCTests: XCTestCase {
     let waxingCrescentEmoji = TinyMoon.MoonPhase.waxingCrescent.emoji
 
     // Returns a New Moon because it falls within this day's 24 hours
-    let date = TinyMoon.formatDate(year: 2024, month: 09, day: 03, hour: 23, minute: 00)
+    let date = TimeTestHelper.formatDate(year: 2024, month: 09, day: 03, hour: 23, minute: 00)
     let moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
@@ -47,91 +47,91 @@ final class UTCTests: XCTestCase {
 
     let newMoonEmoji = TinyMoon.MoonPhase.newMoon.emoji
 
-    var date = TinyMoon.formatDate(year: 2024, month: 01, day: 11)
+    var date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 11)
     var moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 02, day: 09)
+    date = TimeTestHelper.formatDate(year: 2024, month: 02, day: 09)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 03, day: 10)
+    date = TimeTestHelper.formatDate(year: 2024, month: 03, day: 10)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 04, day: 08)
+    date = TimeTestHelper.formatDate(year: 2024, month: 04, day: 08)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 05, day: 08)
+    date = TimeTestHelper.formatDate(year: 2024, month: 05, day: 08)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 06)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 06)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 07, day: 05)
+    date = TimeTestHelper.formatDate(year: 2024, month: 07, day: 05)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 08, day: 04)
+    date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 04)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 09, day: 03)
+    date = TimeTestHelper.formatDate(year: 2024, month: 09, day: 03)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 10, day: 02)
+    date = TimeTestHelper.formatDate(year: 2024, month: 10, day: 02)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 11, day: 01)
+    date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 01)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 12, day: 01)
+    date = TimeTestHelper.formatDate(year: 2024, month: 12, day: 01)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 12, day: 30)
+    date = TimeTestHelper.formatDate(year: 2024, month: 12, day: 30)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
@@ -149,73 +149,73 @@ final class UTCTests: XCTestCase {
 
     let firstQuarterEmoji = TinyMoon.MoonPhase.firstQuarter.emoji
 
-    var date = TinyMoon.formatDate(year: 2024, month: 01, day: 18)
+    var date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 18)
     var moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 02, day: 16)
+    date = TimeTestHelper.formatDate(year: 2024, month: 02, day: 16)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 03, day: 17)
+    date = TimeTestHelper.formatDate(year: 2024, month: 03, day: 17)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 04, day: 15)
+    date = TimeTestHelper.formatDate(year: 2024, month: 04, day: 15)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 05, day: 15)
+    date = TimeTestHelper.formatDate(year: 2024, month: 05, day: 15)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 14)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 14)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 07, day: 13)
+    date = TimeTestHelper.formatDate(year: 2024, month: 07, day: 13)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 08, day: 12)
+    date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 12)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 09, day: 11)
+    date = TimeTestHelper.formatDate(year: 2024, month: 09, day: 11)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 10, day: 10)
+    date = TimeTestHelper.formatDate(year: 2024, month: 10, day: 10)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 11, day: 09)
+    date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 09)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
     if moon.emoji == firstQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 12, day: 08)
+    date = TimeTestHelper.formatDate(year: 2024, month: 12, day: 08)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .firstQuarter)
     XCTAssertEqual(moon.emoji, firstQuarterEmoji)
@@ -234,7 +234,7 @@ final class UTCTests: XCTestCase {
     let waxingGibbousEmoji = TinyMoon.MoonPhase.waxingGibbous.emoji
 
     // At this exact time, the phase is Waxing Gibbous
-    let date = TinyMoon.formatDate(year: 2024, month: 08, day: 19, hour: 00, minute: 00)
+    let date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 19, hour: 00, minute: 00)
     let exactMoon = TinyMoon.calculateExactMoonPhase(date)
     XCTAssertEqual(exactMoon.exactMoonPhase, .waxingGibbous)
     XCTAssertEqual(exactMoon.exactEmoji, waxingGibbousEmoji)
@@ -257,84 +257,84 @@ final class UTCTests: XCTestCase {
 
     let fullMoonEmoji = TinyMoon.MoonPhase.fullMoon.emoji
 
-    var date = TinyMoon.formatDate(year: 2024, month: 01, day: 25)
+    var date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 25)
     var moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 02, day: 24)
+    date = TimeTestHelper.formatDate(year: 2024, month: 02, day: 24)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 03, day: 25)
+    date = TimeTestHelper.formatDate(year: 2024, month: 03, day: 25)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 04, day: 23)
+    date = TimeTestHelper.formatDate(year: 2024, month: 04, day: 23)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 05, day: 23)
+    date = TimeTestHelper.formatDate(year: 2024, month: 05, day: 23)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 22)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 22)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 07, day: 21)
+    date = TimeTestHelper.formatDate(year: 2024, month: 07, day: 21)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 08, day: 19)
+    date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 19)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 09, day: 18)
+    date = TimeTestHelper.formatDate(year: 2024, month: 09, day: 18)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 10, day: 17)
+    date = TimeTestHelper.formatDate(year: 2024, month: 10, day: 17)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 11, day: 15)
+    date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 15)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 12, day: 15)
+    date = TimeTestHelper.formatDate(year: 2024, month: 12, day: 15)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
@@ -352,79 +352,79 @@ final class UTCTests: XCTestCase {
 
     let lastQuarterEmoji = TinyMoon.MoonPhase.lastQuarter.emoji
 
-    var date = TinyMoon.formatDate(year: 2024, month: 01, day: 04)
+    var date = TimeTestHelper.formatDate(year: 2024, month: 01, day: 04)
     var moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 02, day: 02)
+    date = TimeTestHelper.formatDate(year: 2024, month: 02, day: 02)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 03, day: 03)
+    date = TimeTestHelper.formatDate(year: 2024, month: 03, day: 03)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 04, day: 02)
+    date = TimeTestHelper.formatDate(year: 2024, month: 04, day: 02)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 05, day: 01)
+    date = TimeTestHelper.formatDate(year: 2024, month: 05, day: 01)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 05, day: 30)
+    date = TimeTestHelper.formatDate(year: 2024, month: 05, day: 30)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 06, day: 28)
+    date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 28)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 07, day: 28)
+    date = TimeTestHelper.formatDate(year: 2024, month: 07, day: 28)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 08, day: 26)
+    date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 26)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 09, day: 24)
+    date = TimeTestHelper.formatDate(year: 2024, month: 09, day: 24)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 10, day: 24)
+    date = TimeTestHelper.formatDate(year: 2024, month: 10, day: 24)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 11, day: 23)
+    date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 23)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)
     if moon.emoji == lastQuarterEmoji { correct += 1 } else { incorrect += 1 }
 
-    date = TinyMoon.formatDate(year: 2024, month: 12, day: 22)
+    date = TimeTestHelper.formatDate(year: 2024, month: 12, day: 22)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .lastQuarter)
     XCTAssertEqual(moon.emoji, lastQuarterEmoji)


### PR DESCRIPTION
Created `TimeTestHelper` and moved the following methods to that file + updated call sites

```swift
static func formatDate(
    year: [Int](doc://com.apple.documentation/pcwea?language=swift&usr=true),
    month: [Int](doc://com.apple.documentation/pcwea?language=swift&usr=true),
    day: [Int](doc://com.apple.documentation/pcwea?language=swift&usr=true),
    hour: [Int](doc://com.apple.documentation/pcwea?language=swift&usr=true) = 00,
    minute: [Int](doc://com.apple.documentation/pcwea?language=swift&usr=true) = 00,
    second: [Int](doc://com.apple.documentation/pcwea?language=swift&usr=true) = 00,
    timeZone: [TimeZone](doc://com.apple.documentation/qd7hjj?language=swift&usr=true) = TimeZoneOption.createTimeZone(timeZone: .utc)
) -> [Date](doc://com.apple.documentation/17zv1zw?language=swift&usr=true)


static func createTimeZone(timeZone: TimeZoneOption) -> [TimeZone](doc://com.apple.documentation/qd7hjj?language=swift&usr=true)
```