### PR TITLE
Refactor ExactMoon

### DIFF
--- a/Sources/TinyMoon/TinyMoon+ExactMoon.swift
+++ b/Sources/TinyMoon/TinyMoon+ExactMoon.swift
@@ -10,9 +10,7 @@ extension TinyMoon {
   ///
   /// This object represents the precise moon phase for a given date and time, without prioritizing major moon phases (new moon, first quarter, full moon, last quarter)  over others. It provides a more detailed and accurate representation of the moon's phase, suitable for applications requiring precise lunar data.
   ///
-  /// Use `exactMoonPhase` when the specificity of the lunar phase is critical to your application, such as in astronomical apps or detailed lunar tracking that rely on precise moon phase calculations.
-  ///
-  /// - Note: Unlike `moonPhase`, which may prioritize major moon phases occurring at any point within a 24-hour period, `exactMoonPhase` focuses on the exact lunar phase at the given moment.
+  /// `ExactMoon` focuses on the exact lunar phase at the given moment, unlike `Moon`, which may prioritize major moon phases occurring at any point within a 24-hour period.
   ///
   /// For example, given that the full moon occurs on `August 19, 2024 at 13:25 UTC` and the date we query for is `August 19, 2024 at 00:00 UTC`, this object will return `.waxingGibbous` because that is a more accurate representation of the moon phase at `00:00 UTC` time.
   public struct ExactMoon: Hashable {
@@ -21,16 +19,16 @@ extension TinyMoon {
 
     init(date: Date, phaseFraction: Double) {
       self.date = date
-      exactMoonPhase = ExactMoon.exactMoonPhase(phaseFraction: phaseFraction)
-      exactName = exactMoonPhase.rawValue
-      exactEmoji = exactMoonPhase.emoji
+      moonPhase = ExactMoon.exactMoonPhase(phaseFraction: phaseFraction)
+      name = moonPhase.rawValue
+      emoji = moonPhase.emoji
     }
 
     // MARK: Public
 
-    public let exactMoonPhase: MoonPhase
-    public let exactName: String
-    public let exactEmoji: String
+    public let moonPhase: MoonPhase
+    public let name: String
+    public let emoji: String
     public let date: Date
 
     // MARK: Internal

--- a/Sources/TinyMoon/TinyMoon+ExactMoon.swift
+++ b/Sources/TinyMoon/TinyMoon+ExactMoon.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-// MARK: - TinyMoon + ExactMoon
+// MARK: - TinyMoon.ExactMoon
 
 extension TinyMoon {
 
@@ -12,14 +12,23 @@ extension TinyMoon {
   ///
   /// `ExactMoon` focuses on the exact lunar phase at the given moment, unlike `Moon`, which may prioritize major moon phases occurring at any point within a 24-hour period.
   ///
-  /// For example, given that the full moon occurs on `August 19, 2024 at 13:25 UTC` and the date we query for is `August 19, 2024 at 00:00 UTC`, this object will return `.waxingGibbous` because that is a more accurate representation of the moon phase at `00:00 UTC` time.
+  /// For example, given that the full moon occurs on `August 19, 2024 at 13:25 UTC` and the date we query for is `August 19, 2024 at 00:00 UTC`, this object will return `.waxingGibbous` because that is a more accurate representation of the moon phase at `00:00 UTC` time. `Moon` would return `.fullMoon` since a Full Moon happens during that day.
   public struct ExactMoon: Hashable {
 
     // MARK: Lifecycle
 
-    init(date: Date, phaseFraction: Double) {
+    init(date: Date) {
       self.date = date
+      julianDay = AstronomicalConstant.julianDay(date)
+      let moonDetail = AstronomicalConstant.getMoonPhase(julianDay: julianDay)
+      daysElapsedInCycle = moonDetail.daysElapsedInCycle
+      ageOfMoon = moonDetail.ageOfMoon
+      illuminatedFraction = moonDetail.illuminatedFraction
+      distanceFromCenterOfEarth = moonDetail.distanceFromCenterOfEarth
+      phaseFraction = moonDetail.phase
+
       moonPhase = ExactMoon.exactMoonPhase(phaseFraction: phaseFraction)
+
       name = moonPhase.rawValue
       emoji = moonPhase.emoji
     }
@@ -30,6 +39,23 @@ extension TinyMoon {
     public let name: String
     public let emoji: String
     public let date: Date
+    public let julianDay: Double
+    /// Number of days elapsed into the synodic cycle, represented as a fraction
+    public let daysElapsedInCycle: Double
+    /// Age of the moon in days, minutes, hours
+    public let ageOfMoon: (days: Int, hours: Int, minutes: Int)
+    /// Illuminated portion of the Moon, where 0.0 = new and 0.99 = full
+    public let illuminatedFraction: Double
+    /// Distance of moon from the center of the Earth, in kilometers
+    public let distanceFromCenterOfEarth: Double
+    /// Phase of the Moon, represented as a fraction
+    ///
+    /// Varies between `0.0` to `0.99`.
+    /// `0.0` new moon,
+    /// `0.25` first quarter,
+    /// `0.5` full moon,
+    /// `0.75` last quarter
+    public let phaseFraction: Double
 
     // MARK: Internal
 
@@ -54,5 +80,29 @@ extension TinyMoon {
         .newMoon
       }
     }
+  }
+}
+
+extension TinyMoon.ExactMoon {
+  public static func == (lhs: TinyMoon.ExactMoon, rhs: TinyMoon.ExactMoon) -> Bool {
+    lhs.julianDay == rhs.julianDay
+      && lhs.daysElapsedInCycle == rhs.daysElapsedInCycle
+      && lhs.ageOfMoon.days == rhs.ageOfMoon.days
+      && lhs.ageOfMoon.hours == rhs.ageOfMoon.hours
+      && lhs.ageOfMoon.minutes == rhs.ageOfMoon.minutes
+      && lhs.illuminatedFraction == rhs.illuminatedFraction
+      && lhs.distanceFromCenterOfEarth == rhs.distanceFromCenterOfEarth
+      && lhs.phaseFraction == rhs.phaseFraction
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(julianDay)
+    hasher.combine(daysElapsedInCycle)
+    hasher.combine(ageOfMoon.days)
+    hasher.combine(ageOfMoon.hours)
+    hasher.combine(ageOfMoon.minutes)
+    hasher.combine(illuminatedFraction)
+    hasher.combine(distanceFromCenterOfEarth)
+    hasher.combine(phaseFraction)
   }
 }

--- a/Sources/TinyMoon/TinyMoon.swift
+++ b/Sources/TinyMoon/TinyMoon.swift
@@ -19,9 +19,7 @@ public enum TinyMoon {
   ///
   /// This object represents the precise moon phase for a given date and time, without prioritizing major moon phases (new moon, first quarter, full moon, last quarter)  over others. It provides a more detailed and accurate representation of the moon's phase, suitable for applications requiring precise lunar data.
   ///
-  /// Use `exactMoonPhase` when the specificity of the lunar phase is critical to your application, such as in astronomical apps or detailed lunar tracking that rely on precise moon phase calculations.
-  ///
-  /// - Note: Unlike `moonPhase`, which may prioritize major moon phases occurring at any point within a 24-hour period, `exactMoonPhase` focuses on the exact lunar phase at the given moment.
+  /// `ExactMoon` focuses on the exact lunar phase at the given moment, unlike `Moon`, which may prioritize major moon phases occurring at any point within a 24-hour period.
   ///
   /// For example, given that the full moon occurs on `August 19, 2024 at 13:25 UTC` and the date we query for is `August 19, 2024 at 00:00 UTC`, this object will return `.waxingGibbous` because that is a more accurate representation of the moon phase at `00:00 UTC` time.
   public static func calculateExactMoonPhase(_ date: Date = Date()) -> ExactMoon {

--- a/Sources/TinyMoon/TinyMoon.swift
+++ b/Sources/TinyMoon/TinyMoon.swift
@@ -21,10 +21,9 @@ public enum TinyMoon {
   ///
   /// `ExactMoon` focuses on the exact lunar phase at the given moment, unlike `Moon`, which may prioritize major moon phases occurring at any point within a 24-hour period.
   ///
-  /// For example, given that the full moon occurs on `August 19, 2024 at 13:25 UTC` and the date we query for is `August 19, 2024 at 00:00 UTC`, this object will return `.waxingGibbous` because that is a more accurate representation of the moon phase at `00:00 UTC` time.
+  /// For example, given that the full moon occurs on `August 19, 2024 at 13:25 UTC` and the date we query for is `August 19, 2024 at 00:00 UTC`, this object will return `.waxingGibbous` because that is a more accurate representation of the moon phase at `00:00 UTC` time. `Moon` would return `.fullMoon` since a Full Moon happens during that day.
   public static func calculateExactMoonPhase(_ date: Date = Date()) -> ExactMoon {
-    let moon = Moon(date: date)
-    return ExactMoon(date: date, phaseFraction: moon.phaseFraction)
+    ExactMoon(date: date)
   }
 
 }

--- a/Tests/TinyMoonTests/UTCTests.swift
+++ b/Tests/TinyMoonTests/UTCTests.swift
@@ -33,9 +33,9 @@ final class UTCTests: XCTestCase {
 
     // Even though it is the same day, at this exact time, it is not a New Moon
     let exactMoon = TinyMoon.calculateExactMoonPhase(date)
-    XCTAssertEqual(exactMoon.exactEmoji, waxingCrescentEmoji)
-    XCTAssertEqual(exactMoon.exactMoonPhase, .waxingCrescent)
-    if exactMoon.exactEmoji == waxingCrescentEmoji { correct += 1 } else { incorrect += 1 }
+    XCTAssertEqual(exactMoon.emoji, waxingCrescentEmoji)
+    XCTAssertEqual(exactMoon.moonPhase, .waxingCrescent)
+    if exactMoon.emoji == waxingCrescentEmoji { correct += 1 } else { incorrect += 1 }
 
     print("Exact")
     printResults(.newMoon, correct: correct, incorrect: incorrect)
@@ -236,9 +236,9 @@ final class UTCTests: XCTestCase {
     // At this exact time, the phase is Waxing Gibbous
     let date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 19, hour: 00, minute: 00)
     let exactMoon = TinyMoon.calculateExactMoonPhase(date)
-    XCTAssertEqual(exactMoon.exactMoonPhase, .waxingGibbous)
-    XCTAssertEqual(exactMoon.exactEmoji, waxingGibbousEmoji)
-    if exactMoon.exactEmoji == waxingGibbousEmoji { correct += 1 } else { incorrect += 1 }
+    XCTAssertEqual(exactMoon.moonPhase, .waxingGibbous)
+    XCTAssertEqual(exactMoon.emoji, waxingGibbousEmoji)
+    if exactMoon.emoji == waxingGibbousEmoji { correct += 1 } else { incorrect += 1 }
 
     // Although it is the same date and time, since a major phase (Full Moon) occurs within this day's 24 hours, this returns Full Moon
     let moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)

--- a/Tests/TinyMoonTests/UTCTests.swift
+++ b/Tests/TinyMoonTests/UTCTests.swift
@@ -29,12 +29,16 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .newMoon)
     XCTAssertEqual(moon.emoji, newMoonEmoji)
     XCTAssertEqual(moon.daysTillNewMoon, 0)
+    XCTAssertEqual(moon.illuminatedFraction, 0.006961603271078809)
+    XCTAssertEqual(moon.phaseFraction, 0.02658948655549188)
     if moon.emoji == newMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     // Even though it is the same day, at this exact time, it is not a New Moon
     let exactMoon = TinyMoon.calculateExactMoonPhase(date)
     XCTAssertEqual(exactMoon.emoji, waxingCrescentEmoji)
     XCTAssertEqual(exactMoon.moonPhase, .waxingCrescent)
+    XCTAssertEqual(exactMoon.illuminatedFraction, 0.006961603271078809)
+    XCTAssertEqual(exactMoon.phaseFraction, 0.02658948655549188)
     if exactMoon.emoji == waxingCrescentEmoji { correct += 1 } else { incorrect += 1 }
 
     print("Exact")
@@ -238,6 +242,8 @@ final class UTCTests: XCTestCase {
     let exactMoon = TinyMoon.calculateExactMoonPhase(date)
     XCTAssertEqual(exactMoon.moonPhase, .waxingGibbous)
     XCTAssertEqual(exactMoon.emoji, waxingGibbousEmoji)
+    XCTAssertEqual(exactMoon.illuminatedFraction, 0.9911480207511427)
+    XCTAssertEqual(exactMoon.phaseFraction, 0.47000746748499334)
     if exactMoon.emoji == waxingGibbousEmoji { correct += 1 } else { incorrect += 1 }
 
     // Although it is the same date and time, since a major phase (Full Moon) occurs within this day's 24 hours, this returns Full Moon
@@ -245,6 +251,8 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    XCTAssertEqual(moon.illuminatedFraction, 0.9911480207511427)
+    XCTAssertEqual(moon.phaseFraction, 0.47000746748499334)
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     print("Exact")


### PR DESCRIPTION
Closes #39 

API should be ExactMoon.moonPhase, ExactMoon.name, and ExactMoon.emoji instead of the verbose ExactMoon.exactMoonPhase, ExactMoon.exactName, and ExactMoon.exactEmoji.

Also added other useful properties, cush as ageOfMoon, illuminatedFraction, distanceFromEarth + others