### PR TITLE
Add timezone to fullMoonName computed property

### DIFF
--- a/Sources/TinyMoon/TinyMoon+Moon.swift
+++ b/Sources/TinyMoon/TinyMoon+Moon.swift
@@ -21,6 +21,7 @@ extension TinyMoon {
 
     init(date: Date, timeZone: TimeZone = TimeZone.current) {
       self.date = date
+      self.timeZone = timeZone
       julianDay = AstronomicalConstant.julianDay(date)
       let moonDetail = AstronomicalConstant.getMoonPhase(julianDay: julianDay)
       daysElapsedInCycle = moonDetail.daysElapsedInCycle
@@ -67,7 +68,8 @@ extension TinyMoon {
 
     public var fullMoonName: String? {
       if isFullMoon() {
-        let calendar = Calendar.current
+        var calendar = Calendar.current
+        calendar.timeZone = timeZone
         let components = calendar.dateComponents([.month], from: date)
         if let month = components.month {
           return fullMoonName(month: month)
@@ -142,7 +144,6 @@ extension TinyMoon {
 
       return daysUntilNewMoon - 1
     }
-
 
     /// Determines the moon phase for a given date, considering both major and minor moon phases.
     ///
@@ -291,6 +292,8 @@ extension TinyMoon {
 
     // MARK: Private
 
+    private let timeZone: TimeZone
+
     private func fullMoonName(month: Int) -> String? {
       switch month {
       case 1: "Wolf Moon"
@@ -315,7 +318,7 @@ extension TinyMoon {
 // MARK: - TinyMoon.Moon + Equatable
 
 extension TinyMoon.Moon: Equatable {
-  public static func == (lhs: TinyMoon.Moon, rhs: TinyMoon.Moon) -> Bool {
+  public static func ==(lhs: TinyMoon.Moon, rhs: TinyMoon.Moon) -> Bool {
     lhs.julianDay == rhs.julianDay
       && lhs.daysElapsedInCycle == rhs.daysElapsedInCycle
       && lhs.ageOfMoon.days == rhs.ageOfMoon.days

--- a/Tests/TinyMoonTests/Helpers/TimeTestHelper.swift
+++ b/Tests/TinyMoonTests/Helpers/TimeTestHelper.swift
@@ -8,6 +8,7 @@ enum TimeTestHelper {
     case utc
     case pacific
     case tokyo
+    case eastern
 
     static func createTimeZone(timeZone: TimeZoneOption) -> TimeZone {
       switch timeZone {
@@ -17,6 +18,8 @@ enum TimeTestHelper {
         TimeZone(identifier: "America/Los_Angeles")!
       case .tokyo:
         TimeZone(identifier: "Asia/Tokyo")!
+      case .eastern:
+        TimeZone(identifier: "America/New_York")!
       }
     }
   }

--- a/Tests/TinyMoonTests/TinyMoonTests.swift
+++ b/Tests/TinyMoonTests/TinyMoonTests.swift
@@ -330,18 +330,22 @@ final class TinyMoonTests: XCTestCase {
     date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 21, timeZone: pacificTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.fullMoonName, "Strawberry Moon")
 
     date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 22, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.fullMoonName, "Strawberry Moon")
 
     date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 22, timeZone: pacificTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertNotEqual(moon.moonPhase, .fullMoon)
+    XCTAssertNil(moon.fullMoonName)
 
     date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 21, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertNotEqual(moon.moonPhase, .fullMoon)
+    XCTAssertNil(moon.fullMoonName)
 
 
     // Full Moon on
@@ -350,18 +354,22 @@ final class TinyMoonTests: XCTestCase {
     date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 19, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.fullMoonName, "Sturgeon Moon")
 
     date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 20, timeZone: tokyoTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: tokyoTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.fullMoonName, "Sturgeon Moon")
 
     date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 19, timeZone: tokyoTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: tokyoTimeZone)
     XCTAssertNotEqual(moon.moonPhase, .fullMoon)
+    XCTAssertNil(moon.fullMoonName)
 
     date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 20, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertNotEqual(moon.moonPhase, .fullMoon)
+    XCTAssertNil(moon.fullMoonName)
 
     // Full Moon on
     //  - UTC:  Nov 15 21:28
@@ -369,18 +377,22 @@ final class TinyMoonTests: XCTestCase {
     date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 15, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.fullMoonName, "Beaver Moon")
 
     date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 16, timeZone: tokyoTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: tokyoTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.fullMoonName, "Beaver Moon")
 
     date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 16, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertNotEqual(moon.moonPhase, .fullMoon)
+    XCTAssertNil(moon.fullMoonName)
 
     date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 15, timeZone: tokyoTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: tokyoTimeZone)
     XCTAssertNotEqual(moon.moonPhase, .fullMoon)
+    XCTAssertNil(moon.fullMoonName)
   }
 
   // These following moon phases happen within 5 hours of midnight, so these tests aim to check that the phase is calculated correctly and lands on the correct day
@@ -398,6 +410,7 @@ final class TinyMoonTests: XCTestCase {
     var date = TimeTestHelper.formatDate(year: 2024, month: 2, day: 24, hour: 4, minute: 30, timeZone: pacificTimeZone)
     var moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.fullMoonName, "Snow Moon")
 
     // New moon on 3/10/2024 @ 01:00 PST
     date = TimeTestHelper.formatDate(year: 2024, month: 3, day: 10, hour: 1, minute: 0, timeZone: pacificTimeZone)
@@ -408,6 +421,7 @@ final class TinyMoonTests: XCTestCase {
     date = TimeTestHelper.formatDate(year: 2024, month: 3, day: 25, hour: 0, minute: 0, timeZone: pacificTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.fullMoonName, "Worm Moon")
 
     // New moon on 3/10/2024 @ 01:00 PST
     date = TimeTestHelper.formatDate(year: 2024, month: 3, day: 10, hour: 1, minute: 0, timeZone: pacificTimeZone)
@@ -428,6 +442,7 @@ final class TinyMoonTests: XCTestCase {
     date = TimeTestHelper.formatDate(year: 2024, month: 12, day: 15, hour: 1, minute: 01, timeZone: pacificTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: pacificTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.fullMoonName, "Cold Moon")
 
     // MARK: - UTC margin of error tests
     // Values from https://www.timeanddate.com/moon/phases/timezone/utc
@@ -441,6 +456,7 @@ final class TinyMoonTests: XCTestCase {
     date = TimeTestHelper.formatDate(year: 2024, month: 4, day: 23, hour: 23, minute: 48, timeZone: utcTimeZone)
     moon = TinyMoon.calculateMoonPhase(date, timeZone: utcTimeZone)
     XCTAssertEqual(moon.moonPhase, .fullMoon)
+    XCTAssertEqual(moon.fullMoonName, "Pink Moon")
 
     // New moon on 9/3/2024 @ 01:55 UTC
     date = TimeTestHelper.formatDate(year: 2024, month: 9, day: 3, hour: 1, minute: 55, timeZone: utcTimeZone)

--- a/Tests/TinyMoonTests/UTCTests.swift
+++ b/Tests/TinyMoonTests/UTCTests.swift
@@ -253,6 +253,7 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.daysTillFullMoon, 0)
     XCTAssertEqual(moon.illuminatedFraction, 0.9911480207511427)
     XCTAssertEqual(moon.phaseFraction, 0.47000746748499334)
+    XCTAssertEqual(moon.fullMoonName, "Sturgeon Moon")
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     print("Exact")
@@ -270,6 +271,7 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    XCTAssertEqual(moon.fullMoonName, "Wolf Moon")
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TimeTestHelper.formatDate(year: 2024, month: 02, day: 24)
@@ -277,6 +279,7 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    XCTAssertEqual(moon.fullMoonName, "Snow Moon")
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TimeTestHelper.formatDate(year: 2024, month: 03, day: 25)
@@ -284,6 +287,7 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    XCTAssertEqual(moon.fullMoonName, "Worm Moon")
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TimeTestHelper.formatDate(year: 2024, month: 04, day: 23)
@@ -291,6 +295,7 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    XCTAssertEqual(moon.fullMoonName, "Pink Moon")
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TimeTestHelper.formatDate(year: 2024, month: 05, day: 23)
@@ -298,6 +303,7 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    XCTAssertEqual(moon.fullMoonName, "Flower Moon")
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TimeTestHelper.formatDate(year: 2024, month: 06, day: 22)
@@ -305,6 +311,7 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    XCTAssertEqual(moon.fullMoonName, "Strawberry Moon")
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TimeTestHelper.formatDate(year: 2024, month: 07, day: 21)
@@ -312,6 +319,7 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    XCTAssertEqual(moon.fullMoonName, "Buck Moon")
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TimeTestHelper.formatDate(year: 2024, month: 08, day: 19)
@@ -319,6 +327,7 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    XCTAssertEqual(moon.fullMoonName, "Sturgeon Moon")
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TimeTestHelper.formatDate(year: 2024, month: 09, day: 18)
@@ -326,6 +335,7 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    XCTAssertEqual(moon.fullMoonName, "Harvest Moon")
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TimeTestHelper.formatDate(year: 2024, month: 10, day: 17)
@@ -333,6 +343,7 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    XCTAssertEqual(moon.fullMoonName, "Hunter's Moon")
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TimeTestHelper.formatDate(year: 2024, month: 11, day: 15)
@@ -340,6 +351,7 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    XCTAssertEqual(moon.fullMoonName, "Beaver Moon")
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     date = TimeTestHelper.formatDate(year: 2024, month: 12, day: 15)
@@ -347,6 +359,7 @@ final class UTCTests: XCTestCase {
     XCTAssertEqual(moon.moonPhase, .fullMoon)
     XCTAssertEqual(moon.emoji, fullMoonEmoji)
     XCTAssertEqual(moon.daysTillFullMoon, 0)
+    XCTAssertEqual(moon.fullMoonName, "Cold Moon")
     if moon.emoji == fullMoonEmoji { correct += 1 } else { incorrect += 1 }
 
     printResults(.fullMoon, correct: correct, incorrect: incorrect)


### PR DESCRIPTION
Fixes #42 

Potentially fixes a bug where moon.fullMoonName seems to appear the day before a full moon in most cases not on the date of the actual full moon.

I can't recreate it on my end, but i'm hoping to get more details.

Main fix in https://github.com/mannylopez/TinyMoon/pull/43/files#diff-c6e47993b46374061288f1db94533b956582608bb557640c96105dd048974328 and the rest is just adding test cases.